### PR TITLE
feat: allow certificate to be supplied to `serve`

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -16,7 +16,6 @@ interface PrepareServerOptions {
   flags: string[]
   formatExportTypeError?: FormatFunction
   formatImportError?: FormatFunction
-  originProtocol?: string
   port: number
 }
 
@@ -26,7 +25,6 @@ const prepareServer = ({
   flags: denoFlags,
   formatExportTypeError,
   formatImportError,
-  originProtocol,
   port,
 }: PrepareServerOptions) => {
   const processRef: ProcessRef = {}
@@ -59,10 +57,6 @@ const prepareServer = ({
     }
 
     const bootstrapFlags = ['--port', port.toString()]
-
-    if (originProtocol) {
-      bootstrapFlags.push('--origin-protocol', originProtocol)
-    }
 
     await deno.runInBackground(['run', ...denoFlags, stage2Path, ...bootstrapFlags], true, processRef)
 
@@ -134,7 +128,6 @@ const serve = async ({
     flags,
     formatExportTypeError,
     formatImportError,
-    originProtocol: certificatePath ? 'https' : undefined,
     port,
   })
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -70,6 +70,7 @@ const prepareServer = ({
 }
 
 interface ServeOptions {
+  certificatePath?: string
   debug?: boolean
   distImportMapPath?: string
   importMaps?: ImportMapFile[]
@@ -81,6 +82,7 @@ interface ServeOptions {
 }
 
 const serve = async ({
+  certificatePath,
   debug,
   distImportMapPath,
   formatExportTypeError,
@@ -107,6 +109,10 @@ const serve = async ({
   // if any.
   const importMap = new ImportMap(importMaps)
   const flags = ['--allow-all', '--unstable', `--import-map=${importMap.toDataURL()}`]
+
+  if (certificatePath) {
+    flags.push(`--cert=${certificatePath}`)
+  }
 
   if (debug) {
     flags.push('--log-level=debug')


### PR DESCRIPTION
**Which problem is this pull request solving?**

When the `certificatePath` option is supplied to the `serve` method, Edge Bundler will call `deno run` with the `--cert` flag.

Part of https://github.com/netlify/pillar-runtime/issues/323.
