### PR TITLE
chore: update package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
   },
   "keywords": [],
   "license": "MIT",
-  "repository": "netlify-labs/edge-bundler",
+  "repository": "netlify/edge-bundler",
   "bugs": {
-    "url": "https://github.com/netlify-labs/edge-bundler/issues"
+    "url": "https://github.com/netlify/edge-bundler/issues"
   },
   "author": "Netlify Inc.",
   "directories": {


### PR DESCRIPTION
Updates a couple of fields in `package.json` with the correct package name.