### PR TITLE
chore: add flag to disable code gen from strings

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -123,7 +123,12 @@ const serve = async ({
   // Creating an ImportMap instance with any import maps supplied by the user,
   // if any.
   const importMap = new ImportMap(importMaps)
-  const flags = ['--allow-all', '--unstable', `--import-map=${importMap.toDataURL()}`, '--v8-flags=--disallow-code-generation-from-strings']
+  const flags = [
+    '--allow-all',
+    '--unstable',
+    `--import-map=${importMap.toDataURL()}`,
+    '--v8-flags=--disallow-code-generation-from-strings',
+  ]
 
   if (certificatePath) {
     flags.push(`--cert=${certificatePath}`)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -123,7 +123,7 @@ const serve = async ({
   // Creating an ImportMap instance with any import maps supplied by the user,
   // if any.
   const importMap = new ImportMap(importMaps)
-  const flags = ['--allow-all', '--unstable', `--import-map=${importMap.toDataURL()}`]
+  const flags = ['--allow-all', '--unstable', `--import-map=${importMap.toDataURL()}`, '--v8-flags=--disallow-code-generation-from-strings']
 
   if (certificatePath) {
     flags.push(`--cert=${certificatePath}`)


### PR DESCRIPTION
**Which problem is this pull request solving?**

Adding flag to deno runtime in server startup to disable code gen from strings in order to mimic production environment and throw errors on usage of eval() and new Function() operations.

**List other issues or pull requests related to this problem**

See also [https://github.com/netlify/pillar-runtime/issues/272](https://github.com/netlify/pillar-runtime/issues/272)

**Describe the solution you've chosen**

Added flag as suggested in comments in above issue and verified against a local test function.  The test function I used was
 
```
export default (req, context) => {
  const func = new Function("a", "b", 'return a + " " + b');
  console.log(eval('func("hello", "world")'));
};
```

I deployed this to a production site and got the following errors:
<img width="1152" alt="Screen Shot 2022-06-06 at 1 23 57 PM" src="https://user-images.githubusercontent.com/63815686/172413980-b51a9f93-a0f6-4c6e-a74e-8afe8907e96d.png">
<img width="862" alt="Screen Shot 2022-06-06 at 1 24 15 PM" src="https://user-images.githubusercontent.com/63815686/172414028-f1afdbe5-c846-4253-b972-5092de835929.png">

However, it did run locally:

<img width="593" alt="Screen Shot 2022-06-06 at 1 24 54 PM" src="https://user-images.githubusercontent.com/63815686/172414211-3bdeb78a-c2a2-4793-863f-0d943a426d88.png">

 After adding the flag the function fails in local dev as expected with the same errors:

<img width="1045" alt="Screen Shot 2022-06-07 at 10 38 51 AM" src="https://user-images.githubusercontent.com/63815686/172414331-9d4cfdf5-8e91-4d7e-99b5-11bc100da967.png">
<img width="696" alt="Screen Shot 2022-06-07 at 10 39 02 AM" src="https://user-images.githubusercontent.com/63815686/172414443-b99dab54-e29c-4e0a-aae7-6928921ad7c4.png">



**Checklist**

Please add a `x` inside each checkbox:

- [X] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [X] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
