### PR TITLE
chore: deploy id automation

### DIFF
--- a/.github/workflows/update-bootstrap-deploy-id.yml
+++ b/.github/workflows/update-bootstrap-deploy-id.yml
@@ -1,3 +1,5 @@
+name: Update Bootstrap URL
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update-bootstrap-deploy-id.yml
+++ b/.github/workflows/update-bootstrap-deploy-id.yml
@@ -1,0 +1,27 @@
+on:
+  workflow_dispatch:
+    inputs:
+      bootstrap_deploy_id:
+        description: 'Bootstrap Deploy ID'
+        required: true
+        type: string
+
+jobs:
+  update_bootstrap_url:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Replace Deploy ID
+        run: find ./ -type f -exec sed -i 's/https:\/\/.*--edge-bootstrap\.netlify\.app/https://{{ $inputs.bootstrap_deploy_id }}--edge-bootstrap.netlify.app/g' {} \;
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: 'chore: update edge-bundler-bootstrap'
+          body: 'Updates edge-bundler-bootstrap to [`{{ $inputs.bootstrap_deploy_id }}`](https://app.netlify.com/sites/edge-bootstrap/deploys/{{ $inputs.bootstrap_deploy_id }}).'
+          commit-message: 'chore: update edge-bundler-bootstrap'
+          branch: update-edge-bundler-bootstrap
+          delete-branch: true
+          labels: "type: chore"
+          team-reviewers: "netlify/compute"

--- a/.github/workflows/update-bootstrap-deploy-id.yml
+++ b/.github/workflows/update-bootstrap-deploy-id.yml
@@ -13,15 +13,19 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Replace Deploy ID
-        run: find ./ -type f -exec sed -i 's/https:\/\/.*--edge-bootstrap\.netlify\.app/https://{{ $inputs.bootstrap_deploy_id }}--edge-bootstrap.netlify.app/g' {} \;
+        run:
+          find ./ -type f -exec sed -i 's/https:\/\/.*--edge-bootstrap\.netlify\.app/https://{{
+          $inputs.bootstrap_deploy_id }}--edge-bootstrap.netlify.app/g' {} \;
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
           title: 'chore: update edge-bundler-bootstrap'
-          body: 'Updates edge-bundler-bootstrap to [`{{ $inputs.bootstrap_deploy_id }}`](https://app.netlify.com/sites/edge-bootstrap/deploys/{{ $inputs.bootstrap_deploy_id }}).'
+          body:
+            'Updates edge-bundler-bootstrap to [`{{ $inputs.bootstrap_deploy_id
+            }}`](https://app.netlify.com/sites/edge-bootstrap/deploys/{{ $inputs.bootstrap_deploy_id }}).'
           commit-message: 'chore: update edge-bundler-bootstrap'
           branch: update-edge-bundler-bootstrap
           delete-branch: true
-          labels: "type: chore"
-          team-reviewers: "netlify/compute"
+          labels: 'type: chore'
+          team-reviewers: 'netlify/compute'


### PR DESCRIPTION
This PR adds a GH Actions workflow that opens a PR to update the Edge Bootstrap Deploy ID. I plan to either use a `deploy-succeeded` Netlify hook to call this workflow, or to call it from a GH workflow in edge-functions-bootstrap.

cc https://github.com/netlify/edge-bundler/pull/43#issuecomment-1153822651