### PR TITLE
fix: await lifecycle hooks as they might return promises

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -51,7 +51,7 @@ class DenoBridge {
   }
 
   private async downloadBinary() {
-    this.onBeforeDownload?.()
+    await this.onBeforeDownload?.()
 
     await fs.mkdir(this.cacheDirectory, { recursive: true })
 
@@ -68,14 +68,14 @@ class DenoBridge {
         'There was a problem setting up the Edge Functions environment. To try a manual installation, visit https://ntl.fyi/install-deno.',
       )
 
-      this.onAfterDownload?.(error)
+      await this.onAfterDownload?.(error)
 
       throw error
     }
 
     await this.writeVersionFile(downloadedVersion)
 
-    this.onAfterDownload?.()
+    await this.onAfterDownload?.()
 
     return binaryPath
   }


### PR DESCRIPTION
The lifecycle hooks can return a Promise according to the TS types. In order to not get out of order execution we should await them.

**A picture of a cute animal (not mandatory but encouraged)**
![top-ten-cutest-japanese-wild-animals](https://user-images.githubusercontent.com/231804/175271851-b0cb51a2-3d49-4667-9f10-9ccbae852a57.jpeg)

