### PR TITLE
feat: refresh types on Deno CLI cache

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,6 +9,8 @@ module.exports = {
     sourceType: 'module',
   },
   rules: {
+    complexity: 'off',
+    'max-statements': 'off',
     'node/no-missing-import': 'off',
   },
   overrides: [

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -138,14 +138,6 @@ class DenoBridge {
     return this.currentDownload
   }
 
-  private log(...data: unknown[]) {
-    if (!this.debug) {
-      return
-    }
-
-    console.log(...data)
-  }
-
   private static runWithBinary(binaryPath: string, args: string[], pipeOutput?: boolean) {
     const runDeno = execa(binaryPath, args)
 
@@ -183,6 +175,14 @@ class DenoBridge {
     const downloadedPath = await this.getRemoteBinary()
 
     return { global: false, path: downloadedPath }
+  }
+
+  log(...data: unknown[]) {
+    if (!this.debug) {
+      return
+    }
+
+    console.log(...data)
   }
 
   // Runs the Deno CLI in the background and returns a reference to the child

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -14,6 +14,7 @@ import { bundle as bundleESZIP } from './formats/eszip.js'
 import { bundle as bundleJS } from './formats/javascript.js'
 import { ImportMap, ImportMapFile } from './import_map.js'
 import { writeManifest } from './manifest.js'
+import { ensureLatestTypes } from './types.js'
 
 interface BundleOptions {
   cacheDirectory?: string
@@ -97,6 +98,8 @@ const bundle = async (
     onBeforeDownload,
   })
   const basePath = getBasePath(sourceDirectories)
+
+  await ensureLatestTypes(deno)
 
   // The name of the bundle will be the hash of its contents, which we can't
   // compute until we run the bundle process. For now, we'll use a random ID

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4,6 +4,7 @@ import { DenoBridge, OnAfterDownloadHook, OnBeforeDownloadHook, ProcessRef } fro
 import type { EdgeFunction } from '../edge_function.js'
 import { generateStage2 } from '../formats/javascript.js'
 import { ImportMap, ImportMapFile } from '../import_map.js'
+import { ensureLatestTypes } from '../types.js'
 
 import { killProcess, waitForServer } from './util.js'
 
@@ -119,6 +120,9 @@ const serve = async ({
 
   // Wait for the binary to be downloaded if needed.
   await deno.getBinaryPath()
+
+  // Downloading latest types if needed.
+  await ensureLatestTypes(deno)
 
   // Creating an ImportMap instance with any import maps supplied by the user,
   // if any.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -95,7 +95,6 @@ interface ServeOptions {
   port: number
 }
 
-// eslint-disable-next-line complexity, max-statements
 const serve = async ({
   certificatePath,
   debug,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,78 @@
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+import fetch from 'node-fetch'
+
+import type { DenoBridge } from './bridge.js'
+
+const TYPES_URL = 'https://edge.netlify.com'
+
+// eslint-disable-next-line complexity, max-statements
+const ensureLatestTypes = async (deno: DenoBridge, customTypesURL?: string) => {
+  const typesURL = customTypesURL ?? TYPES_URL
+
+  let [localVersion, remoteVersion] = [await getLocalVersion(deno), '']
+
+  try {
+    remoteVersion = await getRemoteVersion(typesURL)
+  } catch (error) {
+    deno.log('Could not check latest version of types:', error)
+
+    return
+  }
+
+  if (localVersion === remoteVersion) {
+    deno.log('Local version of types is up-to-date:', localVersion)
+
+    return
+  }
+
+  deno.log('Local version of types is outdated, updating:', localVersion)
+
+  try {
+    await deno.run(['run', '-r', typesURL])
+  } catch (error) {
+    deno.log('Could not download latest types:', error)
+
+    return
+  }
+
+  try {
+    await writeVersionFile(deno, remoteVersion)
+  } catch {
+    // no-op
+  }
+}
+
+const getLocalVersion = async (deno: DenoBridge) => {
+  const versionFilePath = join(deno.cacheDirectory, 'types-version.txt')
+
+  try {
+    const version = await fs.readFile(versionFilePath, 'utf8')
+
+    return version
+  } catch {
+    // no-op
+  }
+}
+
+const getRemoteVersion = async (typesURL: string) => {
+  const versionURL = new URL('/version.txt', typesURL)
+  const res = await fetch(versionURL.toString())
+
+  if (res.status !== 200) {
+    throw new Error('Unexpected status code from version endpoint')
+  }
+
+  const version = await res.text()
+
+  return version
+}
+
+const writeVersionFile = async (deno: DenoBridge, version: string) => {
+  const versionFilePath = join(deno.cacheDirectory, 'types-version.txt')
+
+  await fs.writeFile(versionFilePath, version)
+}
+
+export { ensureLatestTypes }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ const ensureLatestTypes = async (deno: DenoBridge, customTypesURL?: string) => {
   deno.log('Local version of types is outdated, updating:', localVersion)
 
   try {
-    await deno.run(['run', '-r', typesURL])
+    await deno.run(['cache', '-r', typesURL])
   } catch (error) {
     deno.log('Could not download latest types:', error)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ import type { DenoBridge } from './bridge.js'
 
 const TYPES_URL = 'https://edge.netlify.com'
 
-// eslint-disable-next-line complexity, max-statements
 const ensureLatestTypes = async (deno: DenoBridge, customTypesURL?: string) => {
   const typesURL = customTypesURL ?? TYPES_URL
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -27,7 +27,7 @@ test('`ensureLatestTypes` updates the Deno CLI cache if the local version of typ
 
   t.true(latestVersionMock.isDone())
   t.is(mock.callCount, 1)
-  t.deepEqual(mock.firstCall.firstArg, ['run', '-r', mockURL])
+  t.deepEqual(mock.firstCall.firstArg, ['cache', '-r', mockURL])
   t.is(versionFile, mockVersion)
 
   mock.restore()

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,82 @@
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+import test from 'ava'
+import nock from 'nock'
+import { stub } from 'sinon'
+import tmp from 'tmp-promise'
+
+import { DenoBridge } from '../src/bridge.js'
+import { ensureLatestTypes } from '../src/types.js'
+
+test('`ensureLatestTypes` updates the Deno CLI cache if the local version of types is outdated', async (t) => {
+  const mockURL = 'https://edge.netlify'
+  const mockVersion = '123456789'
+  const latestVersionMock = nock(mockURL).get('/version.txt').reply(200, mockVersion)
+
+  const tmpDir = await tmp.dir()
+  const deno = new DenoBridge({
+    cacheDirectory: tmpDir.path,
+  })
+
+  const mock = stub(deno, 'run').resolves()
+
+  await ensureLatestTypes(deno, mockURL)
+
+  const versionFile = await fs.readFile(join(tmpDir.path, 'types-version.txt'), 'utf8')
+
+  t.true(latestVersionMock.isDone())
+  t.is(mock.callCount, 1)
+  t.deepEqual(mock.firstCall.firstArg, ['run', '-r', mockURL])
+  t.is(versionFile, mockVersion)
+
+  mock.restore()
+
+  await fs.rmdir(tmpDir.path, { recursive: true })
+})
+
+test('`ensureLatestTypes` does not update the Deno CLI cache if the local version of types is up-to-date', async (t) => {
+  const mockURL = 'https://edge.netlify'
+  const mockVersion = '987654321'
+
+  const tmpDir = await tmp.dir()
+  const versionFilePath = join(tmpDir.path, 'types-version.txt')
+
+  await fs.writeFile(versionFilePath, mockVersion)
+
+  const latestVersionMock = nock(mockURL).get('/version.txt').reply(200, mockVersion)
+  const deno = new DenoBridge({
+    cacheDirectory: tmpDir.path,
+  })
+  const mock = stub(deno, 'run').resolves()
+
+  await ensureLatestTypes(deno, mockURL)
+
+  t.true(latestVersionMock.isDone())
+  t.is(mock.callCount, 0)
+
+  mock.restore()
+
+  await fs.rmdir(tmpDir.path, { recursive: true })
+})
+
+test('`ensureLatestTypes` does not throw if the types URL is not available', async (t) => {
+  const mockURL = 'https://edge.netlify'
+  const latestVersionMock = nock(mockURL).get('/version.txt').reply(500)
+
+  const tmpDir = await tmp.dir()
+  const deno = new DenoBridge({
+    cacheDirectory: tmpDir.path,
+  })
+
+  const mock = stub(deno, 'run').resolves()
+
+  await ensureLatestTypes(deno, mockURL)
+
+  t.true(latestVersionMock.isDone())
+  t.is(mock.callCount, 0)
+
+  mock.restore()
+
+  await fs.rmdir(tmpDir.path, { recursive: true })
+})


### PR DESCRIPTION
As part of https://github.com/netlify/pillar-runtime/issues/322, we'd like customers to start importing the types from `https://edge.netlify.com` rather than `netlify:edge`. To ensure that they always have the latest version of that specifier, and not an outdated version cached by Deno CLI, this PR adds a new `ensureLatestTypes` function that will:

1. Hit the `/version.txt` endpoint exposed by https://github.com/netlify/edge-functions-bootstrap/pull/57 to see what is the latest version of the types
2. Check a `types-version.txt` file locally to see whether the cache was already refreshed for that version
3. If not, run `deno cache -r https://edge.netlify.com` to update the specifier in the Deno CLI cache

`ensureLatestTypes` runs on both `bundle` and `serve`, and any errors resulting from the operation will be handled, so that the application will continue to operate normally if something goes wrong with the HTTP call or the cache refresh.