### PR TITLE
feat: add support for import maps when bundling ESZIP

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,6 +10,7 @@ module.exports = {
   },
   rules: {
     complexity: 'off',
+    'max-lines': 'off',
     'max-statements': 'off',
     'node/no-missing-import': 'off',
   },

--- a/.github/workflows/update-bootstrap-deploy-id.yml
+++ b/.github/workflows/update-bootstrap-deploy-id.yml
@@ -16,8 +16,8 @@ jobs:
 
       - name: Replace Deploy ID
         run:
-          find ./ -type f -exec sed -i 's@https:\/\/.*--edge-bootstrap\.netlify\.app@https://${{
-          inputs.bootstrap_deploy_id }}--edge-bootstrap.netlify.app@g' {} \;
+          find ./ -type f -exec sed -i 's@https:\/\/.*--edge\.netlify\.com@https://${{ inputs.bootstrap_deploy_id
+          }}--edge.netlify.com@g' {} \;
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/deno/bundle.ts
+++ b/deno/bundle.ts
@@ -1,6 +1,6 @@
-import { writeStage2 } from 'https://62bae4994570970008142f1e--edge-bootstrap.netlify.app/bundler/mod.ts'
+import { writeStage2 } from 'https://62d144a15553b50009af7ac6--edge.netlify.com/bundler/mod.ts'
 
 const [payload] = Deno.args
-const { basePath, destPath, functions } = JSON.parse(payload)
+const { basePath, destPath, functions, imports } = JSON.parse(payload)
 
-await writeStage2({ basePath, functions, destPath })
+await writeStage2({ basePath, destPath, functions, imports })

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -53,7 +53,7 @@ class DenoBridge {
   private async downloadBinary() {
     await this.onBeforeDownload?.()
 
-    await fs.mkdir(this.cacheDirectory, { recursive: true })
+    await this.ensureCacheDirectory()
 
     this.log(`Downloading Deno CLI to ${this.cacheDirectory}...`)
 
@@ -150,9 +150,15 @@ class DenoBridge {
   }
 
   private async writeVersionFile(version: string) {
+    await this.ensureCacheDirectory()
+
     const versionFilePath = path.join(this.cacheDirectory, DENO_VERSION_FILE)
 
     await fs.writeFile(versionFilePath, version)
+  }
+
+  async ensureCacheDirectory() {
+    await fs.mkdir(this.cacheDirectory, { recursive: true })
   }
 
   async getBinaryPath() {

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -58,6 +58,7 @@ const createBundleOps = ({
         deno,
         distDirectory,
         functions,
+        importMap,
       }),
     )
   } else {

--- a/src/formats/eszip.ts
+++ b/src/formats/eszip.ts
@@ -5,6 +5,7 @@ import { DenoBridge } from '../bridge.js'
 import type { Bundle } from '../bundle.js'
 import { wrapBundleError } from '../bundle_error.js'
 import { EdgeFunction } from '../edge_function.js'
+import { ImportMap } from '../import_map.js'
 import { getFileHash } from '../utils/sha256.js'
 
 interface BundleESZIPOptions {
@@ -14,6 +15,7 @@ interface BundleESZIPOptions {
   deno: DenoBridge
   distDirectory: string
   functions: EdgeFunction[]
+  importMap: ImportMap
 }
 
 const bundleESZIP = async ({
@@ -23,6 +25,7 @@ const bundleESZIP = async ({
   deno,
   distDirectory,
   functions,
+  importMap,
 }: BundleESZIPOptions): Promise<Bundle> => {
   const extension = '.eszip'
   const destPath = join(distDirectory, `${buildID}${extension}`)
@@ -31,6 +34,7 @@ const bundleESZIP = async ({
     basePath,
     destPath,
     functions,
+    imports: importMap.imports,
   }
   const flags = ['--allow-all']
 

--- a/src/formats/javascript.ts
+++ b/src/formats/javascript.ts
@@ -13,7 +13,7 @@ import { ImportMap } from '../import_map.js'
 import type { FormatFunction } from '../server/server.js'
 import { getFileHash } from '../utils/sha256.js'
 
-const BOOTSTRAP_LATEST = 'https://62bae4994570970008142f1e--edge-bootstrap.netlify.app/bootstrap/index-combined.ts'
+const BOOTSTRAP_LATEST = 'https://62d144a15553b50009af7ac6--edge.netlify.com/bootstrap/index-combined.ts'
 
 interface BundleJSOptions {
   buildID: string

--- a/src/import_map.ts
+++ b/src/import_map.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs'
 import { dirname } from 'path'
 
 const INTERNAL_IMPORTS = {
-  'netlify:edge': 'https://edge-bootstrap.netlify.app/v1/index.ts',
+  'netlify:edge': 'https://edge.netlify.com/v1/index.ts',
 }
 
 interface ImportMapFile {

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,8 @@ const getRemoteVersion = async (typesURL: string) => {
 }
 
 const writeVersionFile = async (deno: DenoBridge, version: string) => {
+  await deno.ensureCacheDirectory()
+
   const versionFilePath = join(deno.cacheDirectory, 'types-version.txt')
 
   await fs.writeFile(versionFilePath, version)

--- a/test/bundler.ts
+++ b/test/bundler.ts
@@ -20,7 +20,15 @@ test('Produces a JavaScript bundle and a manifest file', async (t) => {
       path: '/func1',
     },
   ]
-  const result = await bundle([sourceDirectory], tmpDir.path, declarations)
+  const result = await bundle([sourceDirectory], tmpDir.path, declarations, {
+    importMaps: [
+      {
+        imports: {
+          'alias:bytes': 'https://deno.land/std@0.148.0/fmt/bytes.ts',
+        },
+      },
+    ],
+  })
   const generatedFiles = await fs.readdir(tmpDir.path)
 
   t.is(result.functions.length, 1)
@@ -52,6 +60,13 @@ test('Produces only a ESZIP bundle when the `edge_functions_produce_eszip` featu
     featureFlags: {
       edge_functions_produce_eszip: true,
     },
+    importMaps: [
+      {
+        imports: {
+          'alias:bytes': 'https://deno.land/std@0.148.0/fmt/bytes.ts',
+        },
+      },
+    ],
   })
   const generatedFiles = await fs.readdir(tmpDir.path)
 

--- a/test/bundler.ts
+++ b/test/bundler.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs'
-import { resolve } from 'path'
-import { fileURLToPath } from 'url'
+import { join, resolve } from 'path'
+import { fileURLToPath, pathToFileURL } from 'url'
 
 import test from 'ava'
 import tmp from 'tmp-promise'
@@ -10,9 +10,10 @@ import { bundle } from '../src/bundler.js'
 
 const url = new URL(import.meta.url)
 const dirname = fileURLToPath(url)
+const fixturesDir = resolve(dirname, '..', 'fixtures')
 
 test('Produces a JavaScript bundle and a manifest file', async (t) => {
-  const sourceDirectory = resolve(dirname, '..', 'fixtures', 'project_1', 'functions')
+  const sourceDirectory = resolve(fixturesDir, 'project_1', 'functions')
   const tmpDir = await tmp.dir()
   const declarations = [
     {
@@ -24,7 +25,7 @@ test('Produces a JavaScript bundle and a manifest file', async (t) => {
     importMaps: [
       {
         imports: {
-          'alias:bytes': 'https://deno.land/std@0.148.0/fmt/bytes.ts',
+          'alias:helper': pathToFileURL(join(fixturesDir, 'helper.ts')).toString(),
         },
       },
     ],
@@ -48,7 +49,7 @@ test('Produces a JavaScript bundle and a manifest file', async (t) => {
 })
 
 test('Produces only a ESZIP bundle when the `edge_functions_produce_eszip` feature flag is set', async (t) => {
-  const sourceDirectory = resolve(dirname, '..', 'fixtures', 'project_1', 'functions')
+  const sourceDirectory = resolve(fixturesDir, 'project_1', 'functions')
   const tmpDir = await tmp.dir()
   const declarations = [
     {
@@ -63,7 +64,7 @@ test('Produces only a ESZIP bundle when the `edge_functions_produce_eszip` featu
     importMaps: [
       {
         imports: {
-          'alias:bytes': 'https://deno.land/std@0.148.0/fmt/bytes.ts',
+          'alias:helper': pathToFileURL(join(fixturesDir, 'helper.ts')).toString(),
         },
       },
     ],
@@ -86,7 +87,7 @@ test('Produces only a ESZIP bundle when the `edge_functions_produce_eszip` featu
 })
 
 test('Adds a custom error property to user errors during bundling', async (t) => {
-  const sourceDirectory = resolve(dirname, '..', 'fixtures', 'invalid_functions', 'functions')
+  const sourceDirectory = resolve(fixturesDir, 'invalid_functions', 'functions')
   const tmpDir = await tmp.dir()
   const declarations = [
     {

--- a/test/fixtures/helper.ts
+++ b/test/fixtures/helper.ts
@@ -1,0 +1,1 @@
+export const greet = (name: string) => `Hello, ${name}!`

--- a/test/fixtures/project_1/functions/func1.ts
+++ b/test/fixtures/project_1/functions/func1.ts
@@ -1,7 +1,7 @@
-import { prettyBytes } from 'alias:bytes'
+import { greet } from 'alias:helper'
 
 export default async () => {
-  const bytes = prettyBytes(1337)
+  const greeting = greet('Jane Doe')
 
-  return new Response(bytes)
+  return new Response(greeting)
 }

--- a/test/fixtures/project_1/functions/func1.ts
+++ b/test/fixtures/project_1/functions/func1.ts
@@ -1,1 +1,7 @@
-export default async () => new Response('Hello')
+import { prettyBytes } from 'alias:bytes'
+
+export default async () => {
+  const bytes = prettyBytes(1337)
+
+  return new Response(bytes)
+}


### PR DESCRIPTION
**Which problem is this pull request solving?**

Adds support for import maps when bundling to ESZIP.

Also starts loading the bootstrap layer from https://edge.netlify.com.

**List other issues or pull requests related to this problem**

Builds on top of https://github.com/netlify/edge-functions-bootstrap/pull/60.

Closes https://github.com/netlify/pod-compute/issues/145.