### PR TITLE
feat: accept `basePath` parameter

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -17,6 +17,7 @@ import { writeManifest } from './manifest.js'
 import { ensureLatestTypes } from './types.js'
 
 interface BundleOptions {
+  basePath?: string
   cacheDirectory?: string
   debug?: boolean
   distImportMapPath?: string
@@ -82,6 +83,7 @@ const bundle = async (
   distDirectory: string,
   declarations: Declaration[] = [],
   {
+    basePath: inputBasePath,
     cacheDirectory,
     debug,
     distImportMapPath,
@@ -98,7 +100,7 @@ const bundle = async (
     onAfterDownload,
     onBeforeDownload,
   })
-  const basePath = getBasePath(sourceDirectories)
+  const basePath = getBasePath(sourceDirectories, inputBasePath)
 
   await ensureLatestTypes(deno)
 
@@ -155,7 +157,12 @@ const createFinalBundles = async (bundles: Bundle[], distDirectory: string, buil
   await Promise.all(renamingOps)
 }
 
-const getBasePath = (sourceDirectories: string[]) => {
+const getBasePath = (sourceDirectories: string[], inputBasePath?: string) => {
+  // If there's a specific base path supplied, that takes precedence.
+  if (inputBasePath !== undefined) {
+    return inputBasePath
+  }
+
   // `common-path-prefix` returns an empty string when called with a single
   // path, so we check for that case and return the path itself instead.
   if (sourceDirectories.length === 1) {

--- a/test/bundler.ts
+++ b/test/bundler.ts
@@ -22,6 +22,7 @@ test('Produces a JavaScript bundle and a manifest file', async (t) => {
     },
   ]
   const result = await bundle([sourceDirectory], tmpDir.path, declarations, {
+    basePath: fixturesDir,
     importMaps: [
       {
         imports: {
@@ -58,6 +59,7 @@ test('Produces only a ESZIP bundle when the `edge_functions_produce_eszip` featu
     },
   ]
   const result = await bundle([sourceDirectory], tmpDir.path, declarations, {
+    basePath: fixturesDir,
     featureFlags: {
       edge_functions_produce_eszip: true,
     },

--- a/test/fixtures/helper.ts
+++ b/test/fixtures/helper.ts
@@ -1,1 +1,2 @@
 export const greet = (name: string) => `Hello, ${name}!`
+export const echo = (name: string) => name

--- a/test/fixtures/project_1/functions/func1.ts
+++ b/test/fixtures/project_1/functions/func1.ts
@@ -1,7 +1,9 @@
 import { greet } from 'alias:helper'
 
+import { echo } from '../../helper.ts'
+
 export default async () => {
-  const greeting = greet('Jane Doe')
+  const greeting = greet(echo('Jane Doe'))
 
   return new Response(greeting)
 }


### PR DESCRIPTION
**Which problem is this pull request solving?**

Adds a new `basePath` property to the `bundle` function. When present, that is used instead of the default "common path" approach.