### PR TITLE
feat: add support for `denoDir` parameter

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import commonPathPrefix from 'common-path-prefix'
 import { v4 as uuidv4 } from 'uuid'
 
-import { DenoBridge, OnAfterDownloadHook, OnBeforeDownloadHook } from './bridge.js'
+import { DenoBridge, DenoOptions, OnAfterDownloadHook, OnBeforeDownloadHook } from './bridge.js'
 import type { Bundle } from './bundle.js'
 import type { Declaration } from './declaration.js'
 import { EdgeFunction } from './edge_function.js'
@@ -94,12 +94,18 @@ const bundle = async (
   }: BundleOptions = {},
 ) => {
   const featureFlags = getFlags(inputFeatureFlags)
-  const deno = new DenoBridge({
+  const options: DenoOptions = {
     debug,
     cacheDirectory,
     onAfterDownload,
     onBeforeDownload,
-  })
+  }
+
+  if (cacheDirectory !== undefined && featureFlags.edge_functions_cache_deno_dir) {
+    options.denoDir = join(cacheDirectory, 'deno_dir')
+  }
+
+  const deno = new DenoBridge(options)
   const basePath = getBasePath(sourceDirectories, inputBasePath)
 
   await ensureLatestTypes(deno)
@@ -173,3 +179,4 @@ const getBasePath = (sourceDirectories: string[], inputBasePath?: string) => {
 }
 
 export { bundle }
+export type { BundleOptions }

--- a/src/feature_flags.ts
+++ b/src/feature_flags.ts
@@ -1,4 +1,5 @@
 const defaultFlags: Record<string, boolean> = {
+  edge_functions_cache_deno_dir: false,
   edge_functions_produce_eszip: false,
 }
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

Adds a `denoDir` parameter to the `bundle` function. When set, its value is used to set the `DENO_DIR` environment variable.

**List other issues or pull requests related to this problem**

https://github.com/netlify/pod-compute/issues/161