### PR TITLE
feat: allow setting environment variables and disable extending in DenoServer

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -208,7 +208,7 @@ class DenoBridge {
 
   // Runs the Deno CLI in the background and returns a reference to the child
   // process, awaiting its execution.
-  async run(args: string[], { pipeOutput, env: inputEnv, extendEnv }: RunOptions = {}) {
+  async run(args: string[], { pipeOutput, env: inputEnv, extendEnv = true }: RunOptions = {}) {
     const { path: binaryPath } = await this.getBinaryPath()
     const env = this.getEnvironmentVariables(inputEnv)
     const options: Options = { env, extendEnv }
@@ -218,7 +218,11 @@ class DenoBridge {
 
   // Runs the Deno CLI in the background, assigning a reference of the child
   // process to a `ps` property in the `ref` argument, if one is supplied.
-  async runInBackground(args: string[], ref?: ProcessRef, { pipeOutput, env: inputEnv, extendEnv }: RunOptions = {}) {
+  async runInBackground(
+    args: string[],
+    ref?: ProcessRef,
+    { pipeOutput, env: inputEnv, extendEnv = true }: RunOptions = {},
+  ) {
     const { path: binaryPath } = await this.getBinaryPath()
     const env = this.getEnvironmentVariables(inputEnv)
     const options: Options = { env, extendEnv }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -29,7 +29,7 @@ const prepareServer = ({
   port,
 }: PrepareServerOptions) => {
   const processRef: ProcessRef = {}
-  const startIsolate = async (newFunctions: EdgeFunction[]) => {
+  const startIsolate = async (newFunctions: EdgeFunction[], env: NodeJS.ProcessEnv = {}) => {
     if (processRef?.ps !== undefined) {
       await killProcess(processRef.ps)
     }
@@ -59,7 +59,11 @@ const prepareServer = ({
 
     const bootstrapFlags = ['--port', port.toString()]
 
-    await deno.runInBackground(['run', ...denoFlags, stage2Path, ...bootstrapFlags], true, processRef)
+    await deno.runInBackground(['run', ...denoFlags, stage2Path, ...bootstrapFlags], processRef, {
+      pipeOutput: true,
+      env,
+      extendEnv: false,
+    })
 
     const success = await waitForServer(port, processRef.ps)
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -60,6 +60,9 @@ const prepareServer = ({
 
     const bootstrapFlags = ['--port', port.toString()]
 
+    // We set `extendEnv: false` to avoid polluting the edge function context
+    // with variables from the user's system, since those will not be available
+    // in the production environment.
     await deno.runInBackground(['run', ...denoFlags, stage2Path, ...bootstrapFlags], processRef, {
       pipeOutput: true,
       env,

--- a/test/bridge.ts
+++ b/test/bridge.ts
@@ -124,6 +124,7 @@ test('Does inherit environment variables if `extendEnv` is not set', async (t) =
 
   // The environment sets some variables so let us see what they are and remove them from the result
   const referenceOutput = await deno.run(['test'], { env: {}, extendEnv: true })
+  console.log(referenceOutput?.stdout)
   env.TADA = 'TUDU'
   const result = await deno.run(['test'], { env: { LULU: 'LALA' } })
   let output = result?.stdout ?? ''

--- a/test/bridge.ts
+++ b/test/bridge.ts
@@ -50,7 +50,7 @@ test('Does not inherit environment variables if `extendEnv` is false', async (t)
     tmpDir,
     `#!/usr/bin/env sh
 
-  if [ "$1" == "test"  ]
+  if [ "$1" = "test"  ]
   then
     env
   else
@@ -82,7 +82,7 @@ test('Does inherit environment variables if `extendEnv` is true', async (t) => {
     tmpDir,
     `#!/usr/bin/env sh
 
-  if [ "$1" == "test"  ]
+  if [ "$1" = "test"  ]
   then
     env
   else
@@ -114,7 +114,7 @@ test('Does inherit environment variables if `extendEnv` is not set', async (t) =
     tmpDir,
     `#!/usr/bin/env sh
 
-  if [ "$1" == "test"  ]
+  if [ "$1" = "test"  ]
   then
     env
   else
@@ -124,7 +124,6 @@ test('Does inherit environment variables if `extendEnv` is not set', async (t) =
 
   // The environment sets some variables so let us see what they are and remove them from the result
   const referenceOutput = await deno.run(['test'], { env: {}, extendEnv: true })
-  console.log(referenceOutput?.stdout)
   env.TADA = 'TUDU'
   const result = await deno.run(['test'], { env: { LULU: 'LALA' } })
   let output = result?.stdout ?? ''

--- a/test/bridge.ts
+++ b/test/bridge.ts
@@ -58,7 +58,7 @@ test.serial('Does not inherit environment variables if `extendEnv` is false', as
   fi`,
   )
 
-  // The environment sets some varaibles so let us see what they are and remove them from the result
+  // The environment sets some variables so let us see what they are and remove them from the result
   const referenceOutput = await deno.run(['test'], { env: {}, extendEnv: false })
   env.TADA = 'TUDU'
   const result = await deno.run(['test'], { env: { LULU: 'LALA' }, extendEnv: false })

--- a/test/bridge.ts
+++ b/test/bridge.ts
@@ -44,7 +44,7 @@ const getMockDenoBridge = function (tmpDir: DirectoryResult, mockBinaryOutput: s
   })
 }
 
-test('Does not inherit environment variables if `extendEnv` is false', async (t) => {
+test.serial('Does not inherit environment variables if `extendEnv` is false', async (t) => {
   const tmpDir = await tmp.dir()
   const deno = getMockDenoBridge(
     tmpDir,
@@ -76,7 +76,7 @@ test('Does not inherit environment variables if `extendEnv` is false', async (t)
   await fs.promises.rmdir(tmpDir.path, { recursive: true })
 })
 
-test('Does inherit environment variables if `extendEnv` is true', async (t) => {
+test.serial('Does inherit environment variables if `extendEnv` is true', async (t) => {
   const tmpDir = await tmp.dir()
   const deno = getMockDenoBridge(
     tmpDir,
@@ -108,7 +108,7 @@ test('Does inherit environment variables if `extendEnv` is true', async (t) => {
   await fs.promises.rmdir(tmpDir.path, { recursive: true })
 })
 
-test('Does inherit environment variables if `extendEnv` is not set', async (t) => {
+test.serial('Does inherit environment variables if `extendEnv` is not set', async (t) => {
   const tmpDir = await tmp.dir()
   const deno = getMockDenoBridge(
     tmpDir,

--- a/test/bridge.ts
+++ b/test/bridge.ts
@@ -1,0 +1,141 @@
+import { Buffer } from 'buffer'
+import fs from 'fs'
+import { createRequire } from 'module'
+import { platform, env } from 'process'
+import { PassThrough } from 'stream'
+
+import test from 'ava'
+import nock from 'nock'
+import { spy } from 'sinon'
+import tmp, { DirectoryResult } from 'tmp-promise'
+
+import { DenoBridge } from '../src/bridge.js'
+import { getPlatformTarget } from '../src/platform.js'
+
+const require = createRequire(import.meta.url)
+const archiver = require('archiver')
+
+const getMockDenoBridge = function (tmpDir: DirectoryResult, mockBinaryOutput: string) {
+  const latestVersion = '1.20.3'
+  const data = new PassThrough()
+  const archive = archiver('zip', { zlib: { level: 9 } })
+
+  archive.pipe(data)
+  archive.append(Buffer.from(mockBinaryOutput.replace(/@@@latestVersion@@@/g, latestVersion)), {
+    name: platform === 'win32' ? 'deno.exe' : 'deno',
+  })
+  archive.finalize()
+
+  const target = getPlatformTarget()
+
+  nock('https://dl.deno.land').get('/release-latest.txt').reply(200, `v${latestVersion}`)
+  nock('https://dl.deno.land')
+    .get(`/release/v${latestVersion}/deno-${target}.zip`)
+    .reply(200, () => data)
+
+  const beforeDownload = spy()
+  const afterDownload = spy()
+
+  return new DenoBridge({
+    cacheDirectory: tmpDir.path,
+    onBeforeDownload: beforeDownload,
+    onAfterDownload: afterDownload,
+    useGlobal: false,
+  })
+}
+
+test('Does not inherit environment variables if `extendEnv` is false', async (t) => {
+  const tmpDir = await tmp.dir()
+  const deno = getMockDenoBridge(
+    tmpDir,
+    `#!/usr/bin/env sh
+
+  if [ "$1" == "test"  ]
+  then
+    env
+  else
+    echo "deno @@@latestVersion@@@"
+  fi`,
+  )
+
+  // The environment sets some varaibles so let us see what they are and remove them from the result
+  const referenceOutput = await deno.run(['test'], { env: {}, extendEnv: false })
+  env.TADA = 'TUDU'
+  const result = await deno.run(['test'], { env: { LULU: 'LALA' }, extendEnv: false })
+  let output = result?.stdout ?? ''
+
+  delete env.TADA
+
+  referenceOutput?.stdout.split('\n').forEach((line) => {
+    output = output.replace(line.trim(), '')
+  })
+  output = output.trim().replace(/\n+/, '\n')
+
+  t.is(output, 'LULU=LALA')
+
+  await fs.promises.rmdir(tmpDir.path, { recursive: true })
+})
+
+test('Does inherit environment variables if `extendEnv` is true', async (t) => {
+  const tmpDir = await tmp.dir()
+  const deno = getMockDenoBridge(
+    tmpDir,
+    `#!/usr/bin/env sh
+
+  if [ "$1" == "test"  ]
+  then
+    env
+  else
+    echo "deno @@@latestVersion@@@"
+  fi`,
+  )
+
+  // The environment sets some variables so let us see what they are and remove them from the result
+  const referenceOutput = await deno.run(['test'], { env: {}, extendEnv: true })
+  env.TADA = 'TUDU'
+  const result = await deno.run(['test'], { env: { LULU: 'LALA' }, extendEnv: true })
+  let output = result?.stdout ?? ''
+
+  delete env.TADA
+
+  referenceOutput?.stdout.split('\n').forEach((line) => {
+    output = output.replace(line.trim(), '')
+  })
+  output = output.trim().replace(/\n+/, '\n')
+
+  t.is(output, 'LULU=LALA\nTADA=TUDU')
+
+  await fs.promises.rmdir(tmpDir.path, { recursive: true })
+})
+
+test('Does inherit environment variables if `extendEnv` is not set', async (t) => {
+  const tmpDir = await tmp.dir()
+  const deno = getMockDenoBridge(
+    tmpDir,
+    `#!/usr/bin/env sh
+
+  if [ "$1" == "test"  ]
+  then
+    env
+  else
+    echo "deno @@@latestVersion@@@"
+  fi`,
+  )
+
+  // The environment sets some variables so let us see what they are and remove them from the result
+  const referenceOutput = await deno.run(['test'], { env: {}, extendEnv: true })
+  env.TADA = 'TUDU'
+  const result = await deno.run(['test'], { env: { LULU: 'LALA' } })
+  let output = result?.stdout ?? ''
+
+  delete env.TADA
+
+  referenceOutput?.stdout.split('\n').forEach((line) => {
+    output = output.replace(line.trim(), '')
+  })
+  output = output.trim().replace(/\n+/, '\n')
+
+  t.is(output, 'LULU=LALA\nTADA=TUDU')
+
+  await fs.promises.rmdir(tmpDir.path, { recursive: true })
+})

--- a/test/main.ts
+++ b/test/main.ts
@@ -17,7 +17,7 @@ const archiver = require('archiver')
 
 test('Downloads the Deno CLI on demand and caches it for subsequent calls', async (t) => {
   const latestVersion = '1.20.3'
-  const mockBinaryOutput = `#!/usr/bin/env node\n\nconsole.log("deno ${latestVersion}")`
+  const mockBinaryOutput = `#!/usr/bin/env sh\n\necho "deno ${latestVersion}"`
   const data = new PassThrough()
   const archive = archiver('zip', { zlib: { level: 9 } })
 


### PR DESCRIPTION
This is a prerequisite for https://github.com/netlify/cli/issues/4614.

The PR allows setting environment variables in `deno.run` and `deno.runInBackground` as well as disabling extending of current runtime environment variables. These two options basically are plain `execa` options, which are forwarded to execa.

I disabled the extending of env variables in the DenoServer so that once the CLI sets the variables it will be only those available in deno. With the exception of `DENO_DIR`. `DENO_DIR` is okay to have locally?
