### PR TITLE
feat: retry mechanism for Deno cli run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
+        "async-retry": "^1.3.3",
         "common-path-prefix": "^3.0.0",
         "del": "^6.0.0",
         "env-paths": "^3.0.0",
@@ -26,6 +27,7 @@
         "@commitlint/cli": "^16.0.0",
         "@commitlint/config-conventional": "^16.0.0",
         "@netlify/eslint-config-node": "^4.1.7",
+        "@types/async-retry": "^1.4.4",
         "@types/glob-to-regexp": "^0.4.1",
         "@types/node": "^17.0.21",
         "@types/semver": "^7.3.9",
@@ -1187,6 +1189,15 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/async-retry": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.4.tgz",
+      "integrity": "sha512-IGT+yESLPYje0MV8MfOpT5V5oH9lAKLwlosQRyq75tYJmntkkWcfEThHLxsgYjGmYXJEY7ZZkYPb4xuW+NA6GA==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
     "node_modules/@types/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -1236,6 +1247,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -1766,6 +1783,14 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
       "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/ava": {
       "version": "4.3.0",
@@ -7568,6 +7593,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -9681,6 +9714,15 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/async-retry": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.4.tgz",
+      "integrity": "sha512-IGT+yESLPYje0MV8MfOpT5V5oH9lAKLwlosQRyq75tYJmntkkWcfEThHLxsgYjGmYXJEY7ZZkYPb4xuW+NA6GA==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "*"
+      }
+    },
     "@types/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -9730,6 +9772,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "dev": true
     },
     "@types/semver": {
@@ -10100,6 +10148,14 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
       "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
+    },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "requires": {
+        "retry": "0.13.1"
+      }
     },
     "ava": {
       "version": "4.3.0",
@@ -14270,6 +14326,11 @@
       "requires": {
         "global-dirs": "^0.1.1"
       }
+    },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@commitlint/cli": "^16.0.0",
     "@commitlint/config-conventional": "^16.0.0",
     "@netlify/eslint-config-node": "^4.1.7",
+    "@types/async-retry": "^1.4.4",
     "@types/glob-to-regexp": "^0.4.1",
     "@types/node": "^17.0.21",
     "@types/semver": "^7.3.9",
@@ -79,6 +80,7 @@
     "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
   },
   "dependencies": {
+    "async-retry": "^1.3.3",
     "common-path-prefix": "^3.0.0",
     "del": "^6.0.0",
     "env-paths": "^3.0.0",

--- a/src/formats/eszip.ts
+++ b/src/formats/eszip.ts
@@ -20,11 +20,19 @@ interface BundleESZIPOptions {
   importMap: ImportMap
 }
 
-const runDenoCommandWithRetries = async(deno: DenoBridge, flags: string[], payload: unknown, bundler: string): Promise<void> => {
+const runDenoCommandWithRetries = async (
+  deno: DenoBridge,
+  flags: string[],
+  payload: unknown,
+  bundler: string,
+): Promise<void> => {
   try {
-    await retry(async (bail) => {
-      await deno.run(['run', ...flags, bundler, JSON.stringify(payload)], { pipeOutput: true }).catch(bail)
-    }, { retries: 3 })
+    await retry(
+      async (bail) => {
+        await deno.run(['run', ...flags, bundler, JSON.stringify(payload)], { pipeOutput: true }).catch(bail)
+      },
+      { retries: 3 },
+    )
   } catch (error: unknown) {
     throw wrapBundleError(error, { format: 'eszip' })
   }

--- a/src/formats/javascript.ts
+++ b/src/formats/javascript.ts
@@ -32,9 +32,12 @@ const runDenoCommandWithRetries = async (
   jsBundlePath: string,
 ) => {
   try {
-    await retry(async (bail) => {
-      await deno.run(['bundle', ...flags, stage2Path, jsBundlePath], { pipeOutput: true }).catch(bail)
-    }, { retries: 3 })
+    await retry(
+      async (bail) => {
+        await deno.run(['bundle', ...flags, stage2Path, jsBundlePath], { pipeOutput: true }).catch(bail)
+      },
+      { retries: 3 },
+    )
   } catch (error: unknown) {
     throw wrapBundleError(error, { format: 'javascript' })
   }


### PR DESCRIPTION
🎉 Thanks for sending this pull request! 🎉

Due to the occasional network blip, we see failures on build when modules are fetched from Deno. Given the intermittent nature of these issues, it seems like an ephemeral issue which could be solved using a retry mechanism. I've added the most common/popular retry library I could find and have added that around eszip and js bundling.   

This fixes https://github.com/netlify/pod-compute/issues/165

I ran this locally and confirmed that both eszip and JS generated their respective bundles. 

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**

![image-asset](https://user-images.githubusercontent.com/1155123/182365509-002e81ce-a6ed-4acf-89d4-521bf277fe83.jpeg)
