### PR TITLE
feat: add support for system logger

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -62,7 +62,7 @@ class DenoBridge {
 
     await this.ensureCacheDirectory()
 
-    this.logger.debug(`Downloading Deno CLI to ${this.cacheDirectory}...`)
+    this.logger.system(`Downloading Deno CLI to ${this.cacheDirectory}`)
 
     const binaryPath = await download(this.cacheDirectory, this.versionRange)
     const downloadedVersion = await this.getBinaryVersion(binaryPath)
@@ -98,7 +98,7 @@ class DenoBridge {
 
       return version[1]
     } catch (error) {
-      this.logger.error('Error checking Deno binary version', error)
+      this.logger.system('Error checking Deno binary version', error)
     }
   }
 
@@ -172,7 +172,7 @@ class DenoBridge {
     const globalPath = await this.getGlobalBinary()
 
     if (globalPath !== undefined) {
-      this.logger.debug('Using global installation of Deno CLI')
+      this.logger.system('Using global installation of Deno CLI')
 
       return { global: true, path: globalPath }
     }
@@ -180,7 +180,7 @@ class DenoBridge {
     const cachedPath = await this.getCachedBinary()
 
     if (cachedPath !== undefined) {
-      this.logger.debug('Using cached Deno CLI from', cachedPath)
+      this.logger.system('Using cached Deno CLI from', cachedPath)
 
       return { global: false, path: cachedPath }
     }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,6 +7,7 @@ import semver from 'semver'
 
 import { download } from './downloader.js'
 import { getPathInHome } from './home_path.js'
+import { Logger } from './logger.js'
 import { getBinaryExtension } from './platform.js'
 
 const DENO_VERSION_FILE = 'version.txt'
@@ -19,6 +20,7 @@ interface DenoOptions {
   cacheDirectory?: string
   debug?: boolean
   denoDir?: string
+  logger: Logger
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   useGlobal?: boolean
@@ -38,15 +40,17 @@ class DenoBridge {
   currentDownload?: ReturnType<DenoBridge['downloadBinary']>
   debug: boolean
   denoDir?: string
+  logger: Logger
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   useGlobal: boolean
   versionRange: string
 
-  constructor(options: DenoOptions = {}) {
+  constructor(options: DenoOptions) {
     this.cacheDirectory = options.cacheDirectory ?? getPathInHome('deno-cli')
     this.debug = options.debug ?? false
     this.denoDir = options.denoDir
+    this.logger = options.logger
     this.onAfterDownload = options.onAfterDownload
     this.onBeforeDownload = options.onBeforeDownload
     this.useGlobal = options.useGlobal ?? true
@@ -58,10 +62,10 @@ class DenoBridge {
 
     await this.ensureCacheDirectory()
 
-    this.log(`Downloading Deno CLI to ${this.cacheDirectory}...`)
+    this.logger.debug(`Downloading Deno CLI to ${this.cacheDirectory}...`)
 
     const binaryPath = await download(this.cacheDirectory, this.versionRange)
-    const downloadedVersion = await DenoBridge.getBinaryVersion(binaryPath)
+    const downloadedVersion = await this.getBinaryVersion(binaryPath)
 
     // We should never get here, because it means that `DENO_VERSION_RANGE` is
     // a malformed semver range. If this does happen, let's throw an error so
@@ -83,7 +87,7 @@ class DenoBridge {
     return binaryPath
   }
 
-  static async getBinaryVersion(binaryPath: string) {
+  private async getBinaryVersion(binaryPath: string) {
     try {
       const { stdout } = await execa(binaryPath, ['--version'])
       const version = stdout.match(/^deno ([\d.]+)/)
@@ -93,8 +97,8 @@ class DenoBridge {
       }
 
       return version[1]
-    } catch {
-      // no-op
+    } catch (error) {
+      this.logger.error('Error checking Deno binary version', error)
     }
   }
 
@@ -124,7 +128,7 @@ class DenoBridge {
     }
 
     const globalBinaryName = 'deno'
-    const globalVersion = await DenoBridge.getBinaryVersion(globalBinaryName)
+    const globalVersion = await this.getBinaryVersion(globalBinaryName)
 
     if (globalVersion === undefined || !semver.satisfies(globalVersion, this.versionRange)) {
       return
@@ -168,7 +172,7 @@ class DenoBridge {
     const globalPath = await this.getGlobalBinary()
 
     if (globalPath !== undefined) {
-      this.log('Using global installation of Deno CLI')
+      this.logger.debug('Using global installation of Deno CLI')
 
       return { global: true, path: globalPath }
     }
@@ -176,7 +180,7 @@ class DenoBridge {
     const cachedPath = await this.getCachedBinary()
 
     if (cachedPath !== undefined) {
-      this.log('Using cached Deno CLI from', cachedPath)
+      this.logger.debug('Using cached Deno CLI from', cachedPath)
 
       return { global: false, path: cachedPath }
     }
@@ -194,14 +198,6 @@ class DenoBridge {
     }
 
     return env
-  }
-
-  log(...data: unknown[]) {
-    if (!this.debug) {
-      return
-    }
-
-    console.log(...data)
   }
 
   // Runs the Deno CLI in the background and returns a reference to the child

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -13,6 +13,7 @@ import { findFunctions } from './finder.js'
 import { bundle as bundleESZIP } from './formats/eszip.js'
 import { bundle as bundleJS } from './formats/javascript.js'
 import { ImportMap, ImportMapFile } from './import_map.js'
+import { getLogger, LogFunction } from './logger.js'
 import { writeManifest } from './manifest.js'
 import { ensureLatestTypes } from './types.js'
 
@@ -23,6 +24,7 @@ interface BundleOptions {
   distImportMapPath?: string
   featureFlags?: FeatureFlags
   importMaps?: ImportMapFile[]
+  logFunction?: LogFunction
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
 }
@@ -89,14 +91,17 @@ const bundle = async (
     distImportMapPath,
     featureFlags: inputFeatureFlags,
     importMaps,
+    logFunction,
     onAfterDownload,
     onBeforeDownload,
   }: BundleOptions = {},
 ) => {
+  const logger = getLogger(logFunction)
   const featureFlags = getFlags(inputFeatureFlags)
   const options: DenoOptions = {
     debug,
     cacheDirectory,
+    logger,
     onAfterDownload,
     onBeforeDownload,
   }
@@ -108,7 +113,7 @@ const bundle = async (
   const deno = new DenoBridge(options)
   const basePath = getBasePath(sourceDirectories, inputBasePath)
 
-  await ensureLatestTypes(deno)
+  await ensureLatestTypes(deno, logger)
 
   // The name of the bundle will be the hash of its contents, which we can't
   // compute until we run the bundle process. For now, we'll use a random ID

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -24,9 +24,9 @@ interface BundleOptions {
   distImportMapPath?: string
   featureFlags?: FeatureFlags
   importMaps?: ImportMapFile[]
-  logFunction?: LogFunction
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
+  systemLogger?: LogFunction
 }
 
 interface BundleFormatOptions {
@@ -91,12 +91,12 @@ const bundle = async (
     distImportMapPath,
     featureFlags: inputFeatureFlags,
     importMaps,
-    logFunction,
     onAfterDownload,
     onBeforeDownload,
+    systemLogger,
   }: BundleOptions = {},
 ) => {
-  const logger = getLogger(logFunction)
+  const logger = getLogger(systemLogger, debug)
   const featureFlags = getFlags(inputFeatureFlags)
   const options: DenoOptions = {
     debug,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,16 +1,25 @@
 type LogFunction = (...args: unknown[]) => void
 
-interface Logger {
-  debug: LogFunction
-  error: LogFunction
-  log: LogFunction
+const noopLogger: LogFunction = () => {
+  // no-op
 }
 
-const getLogger = (parentLogger: LogFunction = console.log): Logger => ({
-  debug: (...args: unknown[]) => parentLogger({ level: 'debug' }, ...args),
-  error: (...args: unknown[]) => parentLogger({ level: 'error' }, ...args),
-  log: (...args: unknown[]) => parentLogger({ level: 'info' }, ...args),
-})
+interface Logger {
+  system: LogFunction
+  user: LogFunction
+}
+
+const getLogger = (systemLogger?: LogFunction, debug = false): Logger => {
+  // If there is a system logger configured, we'll use that. If there isn't,
+  // we'll pipe system logs to stdout if `debug` is enabled and swallow them
+  // otherwise.
+  const system = systemLogger ?? (debug ? console.log : noopLogger)
+
+  return {
+    system,
+    user: console.log,
+  }
+}
 
 export { getLogger }
 export type { LogFunction, Logger }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,16 @@
+type LogFunction = (...args: unknown[]) => void
+
+interface Logger {
+  debug: LogFunction
+  error: LogFunction
+  log: LogFunction
+}
+
+const getLogger = (parentLogger: LogFunction = console.log): Logger => ({
+  debug: (...args: unknown[]) => parentLogger({ level: 'debug' }, ...args),
+  error: (...args: unknown[]) => parentLogger({ level: 'error' }, ...args),
+  log: (...args: unknown[]) => parentLogger({ level: 'info' }, ...args),
+})
+
+export { getLogger }
+export type { LogFunction, Logger }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4,6 +4,7 @@ import { DenoBridge, OnAfterDownloadHook, OnBeforeDownloadHook, ProcessRef } fro
 import type { EdgeFunction } from '../edge_function.js'
 import { generateStage2 } from '../formats/javascript.js'
 import { ImportMap, ImportMapFile } from '../import_map.js'
+import { getLogger, LogFunction } from '../logger.js'
 import { ensureLatestTypes } from '../types.js'
 
 import { killProcess, waitForServer } from './util.js'
@@ -17,6 +18,7 @@ interface PrepareServerOptions {
   flags: string[]
   formatExportTypeError?: FormatFunction
   formatImportError?: FormatFunction
+  logFunction?: LogFunction
   port: number
 }
 
@@ -88,6 +90,7 @@ interface ServeOptions {
   distImportMapPath?: string
   inspectSettings?: InspectSettings
   importMaps?: ImportMapFile[]
+  logFunction?: LogFunction
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   formatExportTypeError?: FormatFunction
@@ -103,12 +106,15 @@ const serve = async ({
   formatExportTypeError,
   formatImportError,
   importMaps,
+  logFunction,
   onAfterDownload,
   onBeforeDownload,
   port,
 }: ServeOptions) => {
+  const logger = getLogger(logFunction)
   const deno = new DenoBridge({
     debug,
+    logger,
     onAfterDownload,
     onBeforeDownload,
   })
@@ -121,7 +127,7 @@ const serve = async ({
   await deno.getBinaryPath()
 
   // Downloading latest types if needed.
-  await ensureLatestTypes(deno)
+  await ensureLatestTypes(deno, logger)
 
   // Creating an ImportMap instance with any import maps supplied by the user,
   // if any.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -18,7 +18,6 @@ interface PrepareServerOptions {
   flags: string[]
   formatExportTypeError?: FormatFunction
   formatImportError?: FormatFunction
-  logFunction?: LogFunction
   port: number
 }
 
@@ -90,12 +89,12 @@ interface ServeOptions {
   distImportMapPath?: string
   inspectSettings?: InspectSettings
   importMaps?: ImportMapFile[]
-  logFunction?: LogFunction
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   formatExportTypeError?: FormatFunction
   formatImportError?: FormatFunction
   port: number
+  systemLogger?: LogFunction
 }
 
 const serve = async ({
@@ -106,12 +105,12 @@ const serve = async ({
   formatExportTypeError,
   formatImportError,
   importMaps,
-  logFunction,
   onAfterDownload,
   onBeforeDownload,
   port,
+  systemLogger,
 }: ServeOptions) => {
-  const logger = getLogger(logFunction)
+  const logger = getLogger(systemLogger, debug)
   const deno = new DenoBridge({
     debug,
     logger,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,11 @@ import { join } from 'path'
 import fetch from 'node-fetch'
 
 import type { DenoBridge } from './bridge.js'
+import type { Logger } from './logger.js'
 
 const TYPES_URL = 'https://edge.netlify.com'
 
-const ensureLatestTypes = async (deno: DenoBridge, customTypesURL?: string) => {
+const ensureLatestTypes = async (deno: DenoBridge, logger: Logger, customTypesURL?: string) => {
   const typesURL = customTypesURL ?? TYPES_URL
 
   let [localVersion, remoteVersion] = [await getLocalVersion(deno), '']
@@ -15,23 +16,23 @@ const ensureLatestTypes = async (deno: DenoBridge, customTypesURL?: string) => {
   try {
     remoteVersion = await getRemoteVersion(typesURL)
   } catch (error) {
-    deno.log('Could not check latest version of types:', error)
+    logger.debug('Could not check latest version of types:', error)
 
     return
   }
 
   if (localVersion === remoteVersion) {
-    deno.log('Local version of types is up-to-date:', localVersion)
+    logger.debug('Local version of types is up-to-date:', localVersion)
 
     return
   }
 
-  deno.log('Local version of types is outdated, updating:', localVersion)
+  logger.debug('Local version of types is outdated, updating:', localVersion)
 
   try {
     await deno.run(['cache', '-r', typesURL])
   } catch (error) {
-    deno.log('Could not download latest types:', error)
+    logger.debug('Could not download latest types:', error)
 
     return
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,23 +16,23 @@ const ensureLatestTypes = async (deno: DenoBridge, logger: Logger, customTypesUR
   try {
     remoteVersion = await getRemoteVersion(typesURL)
   } catch (error) {
-    logger.debug('Could not check latest version of types:', error)
+    logger.system('Could not check latest version of types:', error)
 
     return
   }
 
   if (localVersion === remoteVersion) {
-    logger.debug('Local version of types is up-to-date:', localVersion)
+    logger.system('Local version of types is up-to-date:', localVersion)
 
     return
   }
 
-  logger.debug('Local version of types is outdated, updating:', localVersion)
+  logger.system('Local version of types is outdated, updating:', localVersion)
 
   try {
     await deno.run(['cache', '-r', typesURL])
   } catch (error) {
-    logger.debug('Could not download latest types:', error)
+    logger.system('Could not download latest types:', error)
 
     return
   }

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -1,0 +1,61 @@
+import test from 'ava'
+import { stub } from 'sinon'
+
+import { getLogger } from '../src/logger.js'
+
+const consoleLog = console.log
+
+const noopLogger = () => {
+  // no-op
+}
+
+test.afterEach.always(() => {
+  // Restoring global `console.log`.
+  console.log = consoleLog
+})
+
+test.serial('Prints user logs to stdout', (t) => {
+  const mockConsoleLog = stub()
+  console.log = mockConsoleLog
+
+  const logger1 = getLogger(noopLogger, true)
+  const logger2 = getLogger(noopLogger, false)
+
+  logger1.user('Hello with `debug: true`')
+  logger2.user('Hello with `debug: false`')
+
+  t.is(mockConsoleLog.callCount, 2)
+  t.is(mockConsoleLog.firstCall.firstArg, 'Hello with `debug: true`')
+  t.is(mockConsoleLog.secondCall.firstArg, 'Hello with `debug: false`')
+})
+
+test.serial('Prints system logs to the system logger provided', (t) => {
+  const mockSystemLog = stub()
+  const mockConsoleLog = stub()
+  console.log = mockSystemLog
+
+  const logger1 = getLogger(mockSystemLog, true)
+  const logger2 = getLogger(mockSystemLog, false)
+
+  logger1.system('Hello with `debug: true`')
+  logger2.system('Hello with `debug: false`')
+
+  t.is(mockConsoleLog.callCount, 0)
+  t.is(mockSystemLog.callCount, 2)
+  t.is(mockSystemLog.firstCall.firstArg, 'Hello with `debug: true`')
+  t.is(mockSystemLog.secondCall.firstArg, 'Hello with `debug: false`')
+})
+
+test.serial('Prints system logs to stdout if there is no system logger provided and `debug` is enabled', (t) => {
+  const mockConsoleLog = stub()
+  console.log = mockConsoleLog
+
+  const logger1 = getLogger(undefined, true)
+  const logger2 = getLogger(undefined, false)
+
+  logger1.system('Hello with `debug: true`')
+  logger2.system('Hello with `debug: false`')
+
+  t.is(mockConsoleLog.callCount, 1)
+  t.is(mockConsoleLog.firstCall.firstArg, 'Hello with `debug: true`')
+})

--- a/test/main.ts
+++ b/test/main.ts
@@ -10,8 +10,12 @@ import { spy } from 'sinon'
 import tmp from 'tmp-promise'
 
 import { DenoBridge } from '../src/bridge.js'
+import { getLogger } from '../src/logger.js'
 import { getPlatformTarget } from '../src/platform.js'
 
+const testLogger = getLogger(() => {
+  // no-op
+})
 const require = createRequire(import.meta.url)
 const archiver = require('archiver')
 
@@ -36,6 +40,7 @@ test('Downloads the Deno CLI on demand and caches it for subsequent calls', asyn
   const afterDownload = spy()
   const deno = new DenoBridge({
     cacheDirectory: tmpDir.path,
+    logger: testLogger,
     onBeforeDownload: beforeDownload,
     onAfterDownload: afterDownload,
     useGlobal: false,

--- a/test/types.ts
+++ b/test/types.ts
@@ -7,7 +7,12 @@ import { stub } from 'sinon'
 import tmp from 'tmp-promise'
 
 import { DenoBridge } from '../src/bridge.js'
+import { getLogger } from '../src/logger.js'
 import { ensureLatestTypes } from '../src/types.js'
+
+const testLogger = getLogger(() => {
+  // no-op
+})
 
 test('`ensureLatestTypes` updates the Deno CLI cache if the local version of types is outdated', async (t) => {
   const mockURL = 'https://edge.netlify'
@@ -17,11 +22,12 @@ test('`ensureLatestTypes` updates the Deno CLI cache if the local version of typ
   const tmpDir = await tmp.dir()
   const deno = new DenoBridge({
     cacheDirectory: tmpDir.path,
+    logger: testLogger,
   })
 
   const mock = stub(deno, 'run').resolves()
 
-  await ensureLatestTypes(deno, mockURL)
+  await ensureLatestTypes(deno, testLogger, mockURL)
 
   const versionFile = await fs.readFile(join(tmpDir.path, 'types-version.txt'), 'utf8')
 
@@ -47,10 +53,11 @@ test('`ensureLatestTypes` does not update the Deno CLI cache if the local versio
   const latestVersionMock = nock(mockURL).get('/version.txt').reply(200, mockVersion)
   const deno = new DenoBridge({
     cacheDirectory: tmpDir.path,
+    logger: testLogger,
   })
   const mock = stub(deno, 'run').resolves()
 
-  await ensureLatestTypes(deno, mockURL)
+  await ensureLatestTypes(deno, testLogger, mockURL)
 
   t.true(latestVersionMock.isDone())
   t.is(mock.callCount, 0)
@@ -67,11 +74,12 @@ test('`ensureLatestTypes` does not throw if the types URL is not available', asy
   const tmpDir = await tmp.dir()
   const deno = new DenoBridge({
     cacheDirectory: tmpDir.path,
+    logger: testLogger,
   })
 
   const mock = stub(deno, 'run').resolves()
 
-  await ensureLatestTypes(deno, mockURL)
+  await ensureLatestTypes(deno, testLogger, mockURL)
 
   t.true(latestVersionMock.isDone())
   t.is(mock.callCount, 0)


### PR DESCRIPTION
**Which problem is this pull request solving?**

With https://github.com/netlify/build/issues/3220 in the pipeline, we'll be able to capture debug data into our system logs without polluting customer builds logs. This PR takes advantage of that and introduces an optional `logFunction` to both `bundle` and `serve`, which is then used instead of `console.log` to print logs.

When this is in place, Netlify Build will be able to pass along the `systemLog()` utility, which was introduced in https://github.com/netlify/build/pull/4406.