### PR TITLE
feat: use default logger in DenoBridge

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,7 +7,7 @@ import semver from 'semver'
 
 import { download } from './downloader.js'
 import { getPathInHome } from './home_path.js'
-import { getDefaultLogger, Logger } from './logger.js'
+import { getLogger, Logger } from './logger.js'
 import { getBinaryExtension } from './platform.js'
 
 const DENO_VERSION_FILE = 'version.txt'
@@ -50,7 +50,7 @@ class DenoBridge {
     this.cacheDirectory = options.cacheDirectory ?? getPathInHome('deno-cli')
     this.debug = options.debug ?? false
     this.denoDir = options.denoDir
-    this.logger = options.logger ?? getDefaultLogger()
+    this.logger = options.logger ?? getLogger(undefined, options.debug)
     this.onAfterDownload = options.onAfterDownload
     this.onBeforeDownload = options.onBeforeDownload
     this.useGlobal = options.useGlobal ?? true

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,7 +7,7 @@ import semver from 'semver'
 
 import { download } from './downloader.js'
 import { getPathInHome } from './home_path.js'
-import { Logger } from './logger.js'
+import { getDefaultLogger, Logger } from './logger.js'
 import { getBinaryExtension } from './platform.js'
 
 const DENO_VERSION_FILE = 'version.txt'
@@ -20,7 +20,7 @@ interface DenoOptions {
   cacheDirectory?: string
   debug?: boolean
   denoDir?: string
-  logger: Logger
+  logger?: Logger
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   useGlobal?: boolean
@@ -50,7 +50,7 @@ class DenoBridge {
     this.cacheDirectory = options.cacheDirectory ?? getPathInHome('deno-cli')
     this.debug = options.debug ?? false
     this.denoDir = options.denoDir
-    this.logger = options.logger
+    this.logger = options.logger ?? getDefaultLogger()
     this.onAfterDownload = options.onAfterDownload
     this.onBeforeDownload = options.onBeforeDownload
     this.useGlobal = options.useGlobal ?? true

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,6 +9,11 @@ interface Logger {
   user: LogFunction
 }
 
+const getDefaultLogger = (): Logger => ({
+  system: noopLogger,
+  user: console.log,
+})
+
 const getLogger = (systemLogger?: LogFunction, debug = false): Logger => {
   // If there is a system logger configured, we'll use that. If there isn't,
   // we'll pipe system logs to stdout if `debug` is enabled and swallow them
@@ -21,5 +26,5 @@ const getLogger = (systemLogger?: LogFunction, debug = false): Logger => {
   }
 }
 
-export { getLogger }
+export { getDefaultLogger, getLogger }
 export type { LogFunction, Logger }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,11 +9,6 @@ interface Logger {
   user: LogFunction
 }
 
-const getDefaultLogger = (): Logger => ({
-  system: noopLogger,
-  user: console.log,
-})
-
 const getLogger = (systemLogger?: LogFunction, debug = false): Logger => {
   // If there is a system logger configured, we'll use that. If there isn't,
   // we'll pipe system logs to stdout if `debug` is enabled and swallow them
@@ -26,5 +21,5 @@ const getLogger = (systemLogger?: LogFunction, debug = false): Logger => {
   }
 }
 
-export { getDefaultLogger, getLogger }
+export { getLogger }
 export type { LogFunction, Logger }

--- a/test/main.ts
+++ b/test/main.ts
@@ -13,9 +13,6 @@ import { DenoBridge } from '../src/bridge.js'
 import { getLogger } from '../src/logger.js'
 import { getPlatformTarget } from '../src/platform.js'
 
-const testLogger = getLogger(() => {
-  // no-op
-})
 const require = createRequire(import.meta.url)
 const archiver = require('archiver')
 
@@ -40,7 +37,6 @@ test('Downloads the Deno CLI on demand and caches it for subsequent calls', asyn
   const afterDownload = spy()
   const deno = new DenoBridge({
     cacheDirectory: tmpDir.path,
-    logger: testLogger,
     onBeforeDownload: beforeDownload,
     onAfterDownload: afterDownload,
     useGlobal: false,

--- a/test/main.ts
+++ b/test/main.ts
@@ -10,7 +10,6 @@ import { spy } from 'sinon'
 import tmp from 'tmp-promise'
 
 import { DenoBridge } from '../src/bridge.js'
-import { getLogger } from '../src/logger.js'
 import { getPlatformTarget } from '../src/platform.js'
 
 const require = createRequire(import.meta.url)


### PR DESCRIPTION
In #85, the `DenoBridge` constructor requires a `logger` parameter, since a default is not offered. This breaks https://github.com/netlify/cli/pull/4900, since CLI is using `DenoBridge` directly and it's not passing in a logger.

This PR makes the `logger` parameter optional and uses a default logger if one is not supplied.