### PR TITLE
feat: add support for import maps with ESZIP

### DIFF
--- a/common/stage2.ts
+++ b/common/stage2.ts
@@ -1,0 +1,11 @@
+export interface InputFunction {
+  name: string
+  path: string
+}
+
+export interface WriteStage2Options {
+  basePath: string
+  destPath: string
+  functions: InputFunction[]
+  importMapURL?: string
+}

--- a/deno/bundle.ts
+++ b/deno/bundle.ts
@@ -1,6 +1,6 @@
 import { writeStage2 } from './lib/stage2.ts'
 
 const [payload] = Deno.args
-const { basePath, destPath, functions, imports } = JSON.parse(payload)
+const { basePath, destPath, functions, importMapURL } = JSON.parse(payload)
 
-await writeStage2({ basePath, destPath, functions, imports })
+await writeStage2({ basePath, destPath, functions, importMapURL })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.14.1",
       "license": "MIT",
       "dependencies": {
+        "@import-maps/resolve": "^1.0.1",
         "common-path-prefix": "^3.0.0",
         "del": "^6.0.0",
         "env-paths": "^3.0.0",
@@ -914,6 +915,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@import-maps/resolve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@import-maps/resolve/-/resolve-1.0.1.tgz",
+      "integrity": "sha512-tWZNBIS1CoekcwlMuyG2mr0a1Wo5lb5lEHwwWvZo+5GLgr3e9LLDTtmgtCWEwBpXMkxn9D+2W9j2FY6eZQq0tA=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -9509,6 +9515,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@import-maps/resolve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@import-maps/resolve/-/resolve-1.0.1.tgz",
+      "integrity": "sha512-tWZNBIS1CoekcwlMuyG2mr0a1Wo5lb5lEHwwWvZo+5GLgr3e9LLDTtmgtCWEwBpXMkxn9D+2W9j2FY6eZQq0tA=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
   },
   "dependencies": {
+    "@import-maps/resolve": "^1.0.1",
     "common-path-prefix": "^3.0.0",
     "del": "^6.0.0",
     "env-paths": "^3.0.0",

--- a/src/formats/eszip.ts
+++ b/src/formats/eszip.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from 'path'
 import { fileURLToPath } from 'url'
 
+import type { WriteStage2Options } from '../../common/stage2.js'
 import { DenoBridge } from '../bridge.js'
 import type { Bundle } from '../bundle.js'
 import { wrapBundleError } from '../bundle_error.js'
@@ -30,11 +31,11 @@ const bundleESZIP = async ({
   const extension = '.eszip'
   const destPath = join(distDirectory, `${buildID}${extension}`)
   const bundler = getESZIPBundler()
-  const payload = {
+  const payload: WriteStage2Options = {
     basePath,
     destPath,
     functions,
-    imports: importMap.imports,
+    importMapURL: importMap.toDataURL(),
   }
   const flags = ['--allow-all']
 

--- a/src/import_map.ts
+++ b/src/import_map.ts
@@ -34,23 +34,9 @@ class ImportMap {
 
   static resolve(importMapFile: ImportMapFile) {
     const { baseURL, ...importMap } = importMapFile
+    const parsedImportMap = parse(importMap, baseURL)
 
-    // TODO: Add support for `scopes`.
-    const { imports } = parse(importMap, baseURL)
-
-    if (imports === undefined) {
-      return { imports: {} }
-    }
-
-    const resolvedImports: Record<string, string> = Object.entries(imports).reduce(
-      (acc, [key, value]) => ({
-        ...acc,
-        [key]: value instanceof URL ? value.toString() : value,
-      }),
-      {},
-    )
-
-    return { imports: resolvedImports }
+    return parsedImportMap
   }
 
   getContents() {

--- a/src/import_map.ts
+++ b/src/import_map.ts
@@ -2,24 +2,55 @@ import { Buffer } from 'buffer'
 import { promises as fs } from 'fs'
 import { dirname } from 'path'
 
+import { parse } from '@import-maps/resolve'
+
 const INTERNAL_IMPORTS = {
   'netlify:edge': 'https://edge.netlify.com/v1/index.ts',
 }
 
 interface ImportMapFile {
+  baseURL: URL
   imports: Record<string, string>
-  scopes?: Record<string, string>
+  scopes?: Record<string, Record<string, string>>
 }
 
 class ImportMap {
   imports: Record<string, string>
 
   constructor(input: ImportMapFile[] = []) {
-    const inputImports = input.reduce((acc, { imports }) => ({ ...acc, ...imports }), {})
+    const inputImports = input.reduce((acc, importMapFile) => {
+      const { imports } = ImportMap.resolve(importMapFile)
+
+      return {
+        ...acc,
+        ...imports,
+      }
+    }, {})
 
     // `INTERNAL_IMPORTS` must come last,
     // because we need to guarantee `netlify:edge` isn't user-defined.
     this.imports = { ...inputImports, ...INTERNAL_IMPORTS }
+  }
+
+  static resolve(importMapFile: ImportMapFile) {
+    const { baseURL, ...importMap } = importMapFile
+
+    // TODO: Add support for `scopes`.
+    const { imports } = parse(importMap, baseURL)
+
+    if (imports === undefined) {
+      return { imports: {} }
+    }
+
+    const resolvedImports: Record<string, string> = Object.entries(imports).reduce(
+      (acc, [key, value]) => ({
+        ...acc,
+        [key]: value instanceof URL ? value.toString() : value,
+      }),
+      {},
+    )
+
+    return { imports: resolvedImports }
   }
 
   getContents() {

--- a/test/import_map.ts
+++ b/test/import_map.ts
@@ -1,0 +1,38 @@
+import test from 'ava'
+
+import { ImportMap } from '../src/import_map.js'
+
+test('Handles import maps with full URLs without specifying a base URL', (t) => {
+  const inputFile1 = {
+    baseURL: new URL('file:///some/path/import-map.json'),
+    imports: {
+      'alias:jamstack': 'https://jamstack.org',
+    },
+  }
+  const inputFile2 = {
+    baseURL: new URL('file:///some/path/import-map.json'),
+    imports: {
+      'alias:pets': 'https://petsofnetlify.com/',
+    },
+  }
+
+  const map = new ImportMap([inputFile1, inputFile2])
+
+  t.is(map.imports['netlify:edge'], 'https://edge.netlify.com/v1/index.ts')
+  t.is(map.imports['alias:jamstack'], 'https://jamstack.org/')
+  t.is(map.imports['alias:pets'], 'https://petsofnetlify.com/')
+})
+
+test('Handles import maps with relative paths', (t) => {
+  const inputFile1 = {
+    baseURL: new URL('file:///Users/jane-doe/my-site/import-map.json'),
+    imports: {
+      'alias:pets': './heart/pets/',
+    },
+  }
+
+  const map = new ImportMap([inputFile1])
+
+  t.is(map.imports['netlify:edge'], 'https://edge.netlify.com/v1/index.ts')
+  t.is(map.imports['alias:pets'], 'file:///Users/jane-doe/my-site/heart/pets/')
+})

--- a/test/import_map.ts
+++ b/test/import_map.ts
@@ -17,10 +17,11 @@ test('Handles import maps with full URLs without specifying a base URL', (t) => 
   }
 
   const map = new ImportMap([inputFile1, inputFile2])
+  const { imports } = JSON.parse(map.getContents())
 
-  t.is(map.imports['netlify:edge'], 'https://edge.netlify.com/v1/index.ts')
-  t.is(map.imports['alias:jamstack'], 'https://jamstack.org/')
-  t.is(map.imports['alias:pets'], 'https://petsofnetlify.com/')
+  t.is(imports['netlify:edge'], 'https://edge.netlify.com/v1/index.ts')
+  t.is(imports['alias:jamstack'], 'https://jamstack.org/')
+  t.is(imports['alias:pets'], 'https://petsofnetlify.com/')
 })
 
 test('Handles import maps with relative paths', (t) => {
@@ -32,7 +33,8 @@ test('Handles import maps with relative paths', (t) => {
   }
 
   const map = new ImportMap([inputFile1])
+  const { imports } = JSON.parse(map.getContents())
 
-  t.is(map.imports['netlify:edge'], 'https://edge.netlify.com/v1/index.ts')
-  t.is(map.imports['alias:pets'], 'file:///Users/jane-doe/my-site/heart/pets/')
+  t.is(imports['netlify:edge'], 'https://edge.netlify.com/v1/index.ts')
+  t.is(imports['alias:pets'], 'file:///Users/jane-doe/my-site/heart/pets/')
 })


### PR DESCRIPTION
Support for import maps was limited when producing ESZIP bundles, because thee loader function wasn't being called for specifiers that looked like relative file paths, and therefore those were not respecting the import map.

With this PR, we're using native support for import maps in https://deno.land/x/eszip@v0.28.0 rather than resolving them ourselves in the loader function.

**NOTE**: Netlify Build will need to start sending a `baseURL` property with the path of the import map file itself ([here](https://github.com/netlify/build/blob/856e361f9b6646469ca8752598f0e486fc3c5b4a/packages/build/src/plugins_core/edge_functions/index.js#L59)), so that we know how to resolve any relative paths in the import map.

Closes https://github.com/netlify/edge-bundler/issues/108.