### PR TITLE
fix: use right location for Deno bundler

### DIFF
--- a/node/formats/eszip.ts
+++ b/node/formats/eszip.ts
@@ -1,5 +1,4 @@
-import { join, resolve } from 'path'
-import { fileURLToPath } from 'url'
+import { join } from 'path'
 
 import type { WriteStage2Options } from '../../shared/stage2.js'
 import { DenoBridge } from '../bridge.js'
@@ -7,6 +6,7 @@ import type { Bundle } from '../bundle.js'
 import { wrapBundleError } from '../bundle_error.js'
 import { EdgeFunction } from '../edge_function.js'
 import { ImportMap } from '../import_map.js'
+import { getPackagePath } from '../package_json.js'
 import { getFileHash } from '../utils/sha256.js'
 
 interface BundleESZIPOptions {
@@ -55,9 +55,8 @@ const bundleESZIP = async ({
 }
 
 const getESZIPBundler = () => {
-  const url = new URL(import.meta.url)
-  const pathname = fileURLToPath(url)
-  const bundlerPath = resolve(pathname, '../../../deno/bundle.ts')
+  const packagePath = getPackagePath()
+  const bundlerPath = join(packagePath, 'deno', 'bundle.ts')
 
   return bundlerPath
 }

--- a/node/package_json.ts
+++ b/node/package_json.ts
@@ -1,16 +1,26 @@
 import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
 
 import { findUpSync } from 'find-up'
 
-const getPackageVersion = () => {
+const getPackagePath = () => {
   const packageJSONPath = findUpSync('package.json', { cwd: import.meta.url })
 
+  // We should never get here, but let's show a somewhat useful error message.
   if (packageJSONPath === undefined) {
-    return ''
+    throw new Error(
+      'Could not find `package.json` for `@netlify/edge-bundler`. Please try running `npm install` to reinstall your dependencies.',
+    )
   }
 
+  return dirname(packageJSONPath)
+}
+
+const getPackageVersion = () => {
+  const packagePath = getPackagePath()
+
   try {
-    const packageJSON = readFileSync(packageJSONPath, 'utf8')
+    const packageJSON = readFileSync(join(packagePath, 'package.json'), 'utf8')
     const { version } = JSON.parse(packageJSON)
 
     return version as string
@@ -19,4 +29,4 @@ const getPackageVersion = () => {
   }
 }
 
-export { getPackageVersion }
+export { getPackagePath, getPackageVersion }


### PR DESCRIPTION
Another follow up to #117! 😓 

Similarly to #118, we were also hardcoding the relative path to the Deno bundler. This PR uses the package path to compute it instead.