### PR TITLE
fix: run `deno` with `--no-config`

### DIFF
--- a/node/formats/eszip.ts
+++ b/node/formats/eszip.ts
@@ -37,7 +37,7 @@ const bundleESZIP = async ({
     functions,
     importMapURL: importMap.toDataURL(),
   }
-  const flags = ['--allow-all']
+  const flags = ['--allow-all', '--no-config']
 
   if (!debug) {
     flags.push('--quiet')

--- a/node/formats/javascript.ts
+++ b/node/formats/javascript.ts
@@ -35,7 +35,7 @@ const bundleJS = async ({
   const stage2Path = await generateStage2({ distDirectory, functions, fileName: `${buildID}-pre.js` })
   const extension = '.js'
   const jsBundlePath = join(distDirectory, `${buildID}${extension}`)
-  const flags = [`--import-map=${importMap.toDataURL()}`]
+  const flags = [`--import-map=${importMap.toDataURL()}`, '--no-config']
 
   if (!debug) {
     flags.push('--quiet')

--- a/node/server/server.ts
+++ b/node/server/server.ts
@@ -143,6 +143,7 @@ const serve = async ({
     '--unstable',
     `--import-map=${importMap.toDataURL()}`,
     '--v8-flags=--disallow-code-generation-from-strings',
+    '--no-config',
   ]
 
   if (certificatePath) {

--- a/test/node/bundler.ts
+++ b/test/node/bundler.ts
@@ -255,7 +255,7 @@ test.serial('Ignores any user-defined `deno.json` files', async (t) => {
     importMap: importMapFile.path,
   }
 
-  // Let's ensure we're not overwriting a `deno.json` file that happens to br
+  // Let's ensure we're not overwriting a `deno.json` file that happens to be
   // in the current working directory.
   await t.throwsAsync(
     () => fs.access(denoConfigPath),

--- a/test/node/bundler.ts
+++ b/test/node/bundler.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs'
 import { join, resolve } from 'path'
+import process from 'process'
 import { fileURLToPath, pathToFileURL } from 'url'
 
 import test from 'ava'
@@ -222,4 +223,66 @@ test('Supports import maps with relative paths', async (t) => {
   t.true(generatedFiles.includes(bundles[0].asset))
 
   await fs.rmdir(tmpDir.path, { recursive: true })
+})
+
+test.serial('Ignores any user-defined `deno.json` files', async (t) => {
+  const fixtureDir = join(fixturesDir, 'project_1')
+  const tmpDir = await tmp.dir()
+  const declarations = [
+    {
+      function: 'func1',
+      path: '/func1',
+    },
+  ]
+
+  // Creating an import map file that rewires the URL of the Deno registry to
+  // an invalid location.
+  const importMapFile = await tmp.file()
+  const importMap = {
+    imports: {
+      'https://deno.land/': 'https://black.hole/',
+    },
+  }
+
+  await fs.writeFile(importMapFile.path, JSON.stringify(importMap))
+
+  // Deno configuration files need to be in the current working directory.
+  // There's not a great way for us to set the working directory of the `deno`
+  // process that we'll run, so our best bet is to write the file to whatever
+  // is the current working directory now and then clean it up.
+  const denoConfigPath = join(process.cwd(), 'deno.json')
+  const denoConfig = {
+    importMap: importMapFile.path,
+  }
+
+  // Let's ensure we're not overwriting a `deno.json` file that happens to br
+  // in the current working directory.
+  await t.throwsAsync(
+    () => fs.access(denoConfigPath),
+    { code: 'ENOENT' },
+    `The file at '${denoConfigPath} would be overwritten by this test. Please move the file to a different location and try again.'`,
+  )
+
+  await fs.writeFile(denoConfigPath, JSON.stringify(denoConfig))
+
+  await t.notThrowsAsync(() =>
+    bundle([join(fixtureDir, 'functions')], tmpDir.path, declarations, {
+      basePath: fixturesDir,
+      featureFlags: {
+        edge_functions_produce_eszip: true,
+      },
+      importMaps: [
+        {
+          baseURL: pathToFileURL(join(fixturesDir, 'import-map.json')),
+          imports: {
+            'alias:helper': pathToFileURL(join(fixturesDir, 'helper.ts')).toString(),
+          },
+        },
+      ],
+    }),
+  )
+
+  await fs.rmdir(tmpDir.path, { recursive: true })
+  await fs.rm(denoConfigPath, { force: true })
+  await fs.rm(importMapFile.path)
 })

--- a/test/node/bundler.ts
+++ b/test/node/bundler.ts
@@ -4,6 +4,7 @@ import process from 'process'
 import { fileURLToPath, pathToFileURL } from 'url'
 
 import test from 'ava'
+import del from 'del'
 import tmp from 'tmp-promise'
 
 import { BundleError } from '../../node/bundle_error.js'
@@ -282,7 +283,5 @@ test.serial('Ignores any user-defined `deno.json` files', async (t) => {
     }),
   )
 
-  await fs.rmdir(tmpDir.path, { recursive: true })
-  await fs.rm(denoConfigPath, { force: true })
-  await fs.rm(importMapFile.path)
+  await del([tmpDir.path, denoConfigPath, importMapFile.path], { force: true })
 })

--- a/test/node/stage_2.ts
+++ b/test/node/stage_2.ts
@@ -6,7 +6,6 @@ import { pathToFileURL } from 'url'
 import test from 'ava'
 import del from 'del'
 import { execa } from 'execa'
-import semver from 'semver'
 import tmp from 'tmp-promise'
 
 import { getLocalEntryPoint } from '../../node/formats/javascript.js'


### PR DESCRIPTION
Adds the `--no-config` flag to the bundling and serving commands. This prevents any user-land configuration files from influencing our internal implementation.

Closes #127.