### PR TITLE
feat: add `functions` level to `metadata` object

### DIFF
--- a/node/formats/javascript.ts
+++ b/node/formats/javascript.ts
@@ -108,7 +108,7 @@ const getLocalEntryPoint = (
   }: GetLocalEntryPointOptions,
 ) => {
   const bootImport = `import { boot } from "${getBootstrapURL()}";`
-  const declaration = `const functions = {}; const metadata = {};`
+  const declaration = `const functions = {}; const metadata = { functions: {} };`
   const imports = functions.map((func) => {
     const url = pathToFileURL(func.path)
     const metadata = {
@@ -121,7 +121,7 @@ const getLocalEntryPoint = (
     
         if (typeof func === "function") {
           functions["${func.name}"] = func;
-          metadata["${func.name}"] = ${JSON.stringify(metadata)}
+          metadata.functions["${func.name}"] = ${JSON.stringify(metadata)}
         } else {
           console.log(${JSON.stringify(formatExportTypeError(func.name))});
         }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test:ci": "run-s build test:ci:*",
     "test:dev:ava": "ava",
     "test:dev:deno": "deno test --allow-all test/deno",
-    "test:ci:ava": "nyc -r lcovonly -r text -r json ava"
+    "test:ci:ava": "nyc -r lcovonly -r text -r json ava",
+    "test:ci:deno": "deno test --allow-all test/deno"
   },
   "config": {
     "eslint": "--ignore-path .gitignore --cache --format=codeframe --max-warnings=0 \"{node,scripts,.github}/**/*.{js,ts,md,html}\" \"*.{js,ts,md,html}\"",

--- a/test/deno/stage2.test.ts
+++ b/test/deno/stage2.test.ts
@@ -52,6 +52,6 @@ Deno.test('`getStage2Entry` returns a valid stage 2 file', async () => {
     const result = await mod.functions[func.name]()
 
     assertEquals(await result.text(), func.response)
-    assertEquals(mod.metadata[func.name].url, pathToFileURL(func.path).toString())
+    assertEquals(mod.metadata.functions[func.name].url, pathToFileURL(func.path).toString())
   }
 })

--- a/test/deno/stage2.test.ts
+++ b/test/deno/stage2.test.ts
@@ -41,10 +41,11 @@ Deno.test('`getStage2Entry` returns a valid stage 2 file', async () => {
   const normalizedStage2 = stage2.replaceAll(virtualRoot, `${baseURL.href}/`)
 
   const stage2Path = join(directory, 'stage2.ts')
+  const stage2URL = pathToFileURL(stage2Path)
 
   await Deno.writeTextFile(stage2Path, normalizedStage2)
 
-  const mod = await import(stage2Path)
+  const mod = await import(stage2URL.href)
 
   await Deno.remove(directory, { recursive: true })
 

--- a/test/node/stage_2.ts
+++ b/test/node/stage_2.ts
@@ -59,7 +59,7 @@ test('`getLocalEntryPoint` returns a valid stage 2 file for local development', 
 
   for (const func of functions) {
     t.is(responses[func.name], func.response)
-    t.is(metadata[func.name].url, pathToFileURL(func.path).toString())
+    t.is(metadata.functions[func.name].url, pathToFileURL(func.path).toString())
   }
 
   await del(tmpDir, { force: true })


### PR DESCRIPTION
Follow up to #122 and #126, which haven't been released yet (see #125). It changes the shape of the `metadata` object to have function-specific metadata under a `functions` key.

_Before:_
```ts
export const metadata = {
  func1: {
    url: "file:///some/path/func1.ts"
  },
  func2: {
    url: "file:///some/path/func2.ts"
  }
}
```

_After:_
```ts
export const metadata = {
  functions: {
    func1: {
      url: "file:///some/path/func1.ts"
    },
    func2: {
      url: "file:///some/path/func2.ts"
    }
  }
}
```

This will allow us to more easily export additional metadata that is not tied to a specific function (e.g. the path of the stage 2 file).