### PR TITLE
feat!: change format of `functions` export

### DIFF
--- a/test/deno/stage2.test.ts
+++ b/test/deno/stage2.test.ts
@@ -50,9 +50,10 @@ Deno.test('`getStage2Entry` returns a valid stage 2 file', async () => {
   await Deno.remove(directory, { recursive: true })
 
   for (const func of functions) {
-    const result = await mod.functions[func.name]()
+    const { handler, url } = mod.functions[func.name]
+    const result = await handler()
 
     assertEquals(await result.text(), func.response)
-    assertEquals(mod.metadata.functions[func.name].url, pathToFileURL(func.path).toString())
+    assertEquals(url, pathToFileURL(func.path).toString())
   }
 })

--- a/test/node/stage_2.ts
+++ b/test/node/stage_2.ts
@@ -8,24 +8,28 @@ import del from 'del'
 import { execa } from 'execa'
 import tmp from 'tmp-promise'
 
-import { getLocalEntryPoint } from '../../node/formats/javascript.js'
+import { getLocalEntryPoint, getProductionEntryPoint } from '../../node/formats/javascript.js'
 
-test('`getLocalEntryPoint` returns a valid stage 2 file for local development', async (t) => {
-  const { path: tmpDir } = await tmp.dir()
-
-  // This is a fake bootstrap that we'll create just for the purpose of logging
-  // the functions and the metadata that are sent to the `boot` function.
-  const printer = `
-    export const boot = async (functions, metadata) => {
+// This is a fake bootstrap that we'll create just for the purpose of logging
+// the functions and the metadata that are sent to the `boot` function.
+const printer = `
+    export const boot = async (functions) => {
+      const metadata = {}
       const responses = {}
 
       for (const name in functions) {
-        responses[name] = await functions[name]()
+        const { handler, ...props } = functions[name]
+
+        metadata[name] = props
+        responses[name] = await handler()
       }
 
       console.log(JSON.stringify({ responses, metadata }))
     }
   `
+
+test('`getLocalEntryPoint` returns a valid stage 2 file for local development', async (t) => {
+  const { path: tmpDir } = await tmp.dir()
   const printerPath = join(tmpDir, 'printer.mjs')
 
   await fs.writeFile(printerPath, printer)
@@ -58,7 +62,45 @@ test('`getLocalEntryPoint` returns a valid stage 2 file for local development', 
 
   for (const func of functions) {
     t.is(responses[func.name], func.response)
-    t.is(metadata.functions[func.name].url, pathToFileURL(func.path).toString())
+    t.is(metadata[func.name].url, pathToFileURL(func.path).toString())
+  }
+
+  await del(tmpDir, { force: true })
+  delete process.env.NETLIFY_EDGE_BOOTSTRAP
+})
+
+test('`getProductionEntryPoint` returns a valid stage 2 file for production', async (t) => {
+  const { path: tmpDir } = await tmp.dir()
+  const printerPath = join(tmpDir, 'printer.mjs')
+
+  await fs.writeFile(printerPath, printer)
+  process.env.NETLIFY_EDGE_BOOTSTRAP = pathToFileURL(printerPath).toString()
+
+  const functions = [
+    { name: 'func1', path: join(tmpDir, 'func1.mjs'), response: 'Hello from function 1' },
+    { name: 'func2', path: join(tmpDir, 'func2.mjs'), response: 'Hello from function 2' },
+  ]
+
+  for (const func of functions) {
+    const contents = `export default () => ${JSON.stringify(func.response)}`
+
+    await fs.writeFile(func.path, contents)
+  }
+
+  const stage2 = getProductionEntryPoint(functions.map(({ name, path }) => ({ name, path })))
+  const stage2Path = join(tmpDir, 'stage2.mjs')
+
+  await fs.writeFile(stage2Path, stage2)
+
+  const { stdout, stderr } = await execa('deno', ['run', '--allow-all', stage2Path])
+
+  t.is(stderr, '')
+
+  const { metadata, responses } = JSON.parse(stdout)
+
+  for (const func of functions) {
+    t.is(responses[func.name], func.response)
+    t.is(metadata[func.name].url, pathToFileURL(func.path).toString())
   }
 
   await del(tmpDir, { force: true })


### PR DESCRIPTION
Changes the shape of the `functions` export so that it incorporates the metadata properties added in #122 and #126.

_Before:_
```ts
import func0 from "file:///path/to/func0.ts";
import func1 from "file:///path/to/func1.ts";

export const functions = {"func0": func0, "func1": func1};
export const metadata = {
  "functions": {
    "func0": {
      "url": "file:///path/to/func0.ts"
    },
    "func1": {
      "url": "file:///path/to/func1.ts"
    }
  }
}
```

_After:_
```ts
import func0 from "file:///path/to/func0.ts";
import func1 from "file:///path/to/func1.ts";

export const functions = {
  "func0": {
    "handler": func0,
    "url": "file:///path/to/func0.ts"
  },
  "func1": {
    "handler": func1,
    "url": "file:///path/to/func1.ts"
  }
};
```

This prevents a breaking change between stage 1 and stage 2, as trying to import `metadata` without a matching export will throw an error. Instead, we'll reuse the existing `functions` export and the bootstrap layer can check for its shape and act accordingly.

**This should not be merged before the bootstrap layer PR**