### PR TITLE
fix: require version 1.22.0 of the Deno CLI

### DIFF
--- a/node/bridge.ts
+++ b/node/bridge.ts
@@ -12,7 +12,7 @@ import { getLogger, Logger } from './logger.js'
 import { getBinaryExtension } from './platform.js'
 
 const DENO_VERSION_FILE = 'version.txt'
-const DENO_VERSION_RANGE = '^1.20.3'
+const DENO_VERSION_RANGE = '^1.22.0'
 
 type OnBeforeDownloadHook = () => void | Promise<void>
 type OnAfterDownloadHook = (error?: Error) => void | Promise<void>


### PR DESCRIPTION
#128 added the `--no-config` flag to the Deno CLI, which was added in version 1.22.0. This version is above our current minimum requirement, which is 1.20.3.

This PR updates that.