### PR TITLE
feat: add featureflag to allow usage of global Deno

### DIFF
--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -110,6 +110,10 @@ const bundle = async (
     options.denoDir = join(cacheDirectory, 'deno_dir')
   }
 
+  if (featureFlags.edge_functions_use_global_deno) {
+    options.useGlobal = true
+  }
+
   const deno = new DenoBridge(options)
   const basePath = getBasePath(sourceDirectories, inputBasePath)
 

--- a/node/feature_flags.ts
+++ b/node/feature_flags.ts
@@ -1,6 +1,7 @@
 const defaultFlags: Record<string, boolean> = {
   edge_functions_cache_deno_dir: false,
   edge_functions_produce_eszip: false,
+  edge_functions_use_global_deno: false,
 }
 
 type FeatureFlag = keyof typeof defaultFlags


### PR DESCRIPTION
This PR adds a new featureflag that allows usage of a build-image installed Deno binary, instead of downloading the binary during build.

cc https://github.com/netlify/pillar-workflow/issues/504