### PR TITLE
feat: add support for post-cache routes

### DIFF
--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -7,7 +7,6 @@ import type { Bundle } from './bundle.js'
 import type { Declaration } from './declaration.js'
 import { EdgeFunction } from './edge_function.js'
 import { getPackageVersion } from './package_json.js'
-import { nonNullable } from './utils/non_nullable.js'
 
 interface GenerateManifestOptions {
   bundles?: Bundle[]
@@ -15,15 +14,32 @@ interface GenerateManifestOptions {
   declarations?: Declaration[]
 }
 
-interface Manifest {
-  // eslint-disable-next-line camelcase
-  bundler_version: string
-  bundles: { asset: string; format: string }[]
-  routes: { function: string; pattern: string }[]
+interface PreCacheRoute {
+  function: string
+  pattern: string
 }
 
+interface PostCacheRoute {
+  function: string
+}
+
+/* eslint-disable camelcase */
+interface Manifest {
+  bundler_version: string
+  bundles: { asset: string; format: string }[]
+  routes: PreCacheRoute[]
+  post_cache_routes: PostCacheRoute[]
+}
+/* eslint-enable camelcase */
+
 const generateManifest = ({ bundles = [], declarations = [], functions }: GenerateManifestOptions) => {
-  const routes = declarations.map((declaration) => {
+  const preCacheRoutes: PreCacheRoute[] = []
+  const postCacheRoutes: PostCacheRoute[] = []
+  const functionsProcessed: Set<string> = new Set()
+
+  // To gather the pre-cache routes, we go through all the declarations (order
+  // matters), and pick the ones with a matching function and a pattern.
+  declarations.forEach((declaration) => {
     const func = functions.find(({ name }) => declaration.function === name)
 
     if (func === undefined) {
@@ -31,21 +47,40 @@ const generateManifest = ({ bundles = [], declarations = [], functions }: Genera
     }
 
     const pattern = getRegularExpression(declaration)
+
+    if (pattern === null) {
+      return
+    }
+
     const serializablePattern = pattern.source.replace(/\\\//g, '/')
 
-    return {
+    functionsProcessed.add(func.name)
+
+    preCacheRoutes.push({
       function: func.name,
       pattern: serializablePattern,
-    }
+    })
   })
+
+  // Any functions that don't have a declaration with a pattern are treated as
+  // post-cache functions.
+  functions.forEach((func) => {
+    if (functionsProcessed.has(func.name)) {
+      return
+    }
+
+    postCacheRoutes.push({ function: func.name })
+  })
+
   const manifestBundles = bundles.map(({ extension, format, hash }) => ({
     asset: hash + extension,
     format,
   }))
   const manifest: Manifest = {
-    bundles: manifestBundles,
-    routes: routes.filter(nonNullable),
     bundler_version: getPackageVersion(),
+    bundles: manifestBundles,
+    routes: preCacheRoutes,
+    post_cache_routes: postCacheRoutes,
   }
 
   return manifest
@@ -56,16 +91,20 @@ const getRegularExpression = (declaration: Declaration) => {
     return new RegExp(declaration.pattern)
   }
 
-  // We use the global flag so that `globToRegExp` will not wrap the expression
-  // with `^` and `$`. We'll do that ourselves.
-  const regularExpression = globToRegExp(declaration.path, { flags: 'g' })
+  if ('path' in declaration) {
+    // We use the global flag so that `globToRegExp` will not wrap the expression
+    // with `^` and `$`. We'll do that ourselves.
+    const regularExpression = globToRegExp(declaration.path, { flags: 'g' })
 
-  // Wrapping the expression source with `^` and `$`. Also, adding an optional
-  // trailing slash, so that a declaration of `path: "/foo"` matches requests
-  // for both `/foo` and `/foo/`.
-  const normalizedSource = `^${regularExpression.source}\\/?$`
+    // Wrapping the expression source with `^` and `$`. Also, adding an optional
+    // trailing slash, so that a declaration of `path: "/foo"` matches requests
+    // for both `/foo` and `/foo/`.
+    const normalizedSource = `^${regularExpression.source}\\/?$`
 
-  return new RegExp(normalizedSource)
+    return new RegExp(normalizedSource)
+  }
+
+  return null
 }
 
 interface WriteManifestOptions {

--- a/test/node/manifest.ts
+++ b/test/node/manifest.ts
@@ -27,10 +27,11 @@ test('Generates a manifest with different bundles', (t) => {
 
   t.deepEqual(manifest.bundles, expectedBundles)
   t.deepEqual(manifest.routes, expectedRoutes)
+  t.deepEqual(manifest.post_cache_routes, [])
   t.is(manifest.bundler_version, env.npm_package_version as string)
 })
 
-test('Excludes functions for which there are function files but no matching config declarations', (t) => {
+test('Excludes from `routes` any functions for which there is no config declaration, but adds it to `post_cache_routes`', (t) => {
   const bundle1 = {
     extension: '.ext2',
     format: 'format1',
@@ -43,9 +44,8 @@ test('Excludes functions for which there are function files but no matching conf
   const declarations = [{ function: 'func-1', path: '/f1' }]
   const manifest = generateManifest({ bundles: [bundle1], declarations, functions })
 
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$' }]
-
-  t.deepEqual(manifest.routes, expectedRoutes)
+  t.deepEqual(manifest.routes, [{ function: 'func-1', pattern: '^/f1/?$' }])
+  t.deepEqual(manifest.post_cache_routes, [{ function: 'func-2' }])
 })
 
 test('Excludes functions for which there are config declarations but no matching function files', (t) => {

--- a/test/node/serving.ts
+++ b/test/node/serving.ts
@@ -5,7 +5,7 @@ import test from 'ava'
 import getPort from 'get-port'
 import fetch from 'node-fetch'
 
-import { serve } from '../src/index.js'
+import { serve } from '../../node/index.js'
 
 const url = new URL(import.meta.url)
 const dirname = fileURLToPath(url)


### PR DESCRIPTION
**Which problem is this pull request solving?**

When an edge function file doesn't have a matching declaration with a `path` property, it's deployed as a post-cache edge function.