### PR TITLE
chore: fix version lookup in integration test

### DIFF
--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -8,7 +8,6 @@ import { fileURLToPath, pathToFileURL } from 'url'
 import { promisify } from 'util'
 
 import del from 'del'
-import { findUp } from 'find-up'
 import tar from 'tar'
 import tmp from 'tmp-promise'
 
@@ -21,9 +20,7 @@ const pathsToCleanup = new Set()
 const installPackage = async () => {
   console.log(`Getting package version...`)
 
-  const packageJsonPath = await findUp('package.json')
-  const packageJson = await fs.readFile(packageJsonPath, 'utf8')
-  const { name, version } = JSON.parse(packageJson)
+  const { name, version } = require('../../package.json')
 
   console.log(`Running integration tests for ${name} v${version}...`)
 

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -1,5 +1,6 @@
 import assert from 'assert'
 import childProcess from 'child_process'
+import { promises as fs } from 'fs'
 import { createRequire } from 'module'
 import { join, resolve } from 'path'
 import process from 'process'
@@ -7,6 +8,7 @@ import { fileURLToPath, pathToFileURL } from 'url'
 import { promisify } from 'util'
 
 import del from 'del'
+import { findUp } from 'find-up'
 import tar from 'tar'
 import tmp from 'tmp-promise'
 
@@ -17,17 +19,22 @@ const functionsDir = resolve(fileURLToPath(import.meta.url), '..', 'functions')
 const pathsToCleanup = new Set()
 
 const installPackage = async () => {
-  console.log(`Getting package version from 'npm info'...`)
+  console.log(`Getting package version...`)
 
-  const { stdout: infoOutput } = await exec('npm info --json')
-  const { version } = JSON.parse(infoOutput)
+  const packageJsonPath = await findUp('package.json')
+  const packageJson = await fs.readFile(packageJsonPath, 'utf8')
+  const { name, version } = JSON.parse(packageJson)
+
+  console.log(`Running integration tests for ${name} v${version}...`)
+
   const { path } = await tmp.dir()
 
   console.log(`Creating tarball with 'npm pack'...`)
 
   await exec('npm pack --json')
 
-  const filename = join(process.cwd(), `netlify-edge-bundler-${version}.tgz`)
+  const normalizedName = name.replace(/@/, '').replace(/\W/g, '-')
+  const filename = join(process.cwd(), `${normalizedName}-${version}.tgz`)
 
   console.log(`Uncompressing the tarball at '${filename}'...`)
 


### PR DESCRIPTION
When the integration test runs in a release branch, the version returned by `npm info` is no longer the version we're looking to test. Instead, we want to pull that version from `package.json`.