### PR TITLE
fix: use `allow-net` flag to run `config` function

### DIFF
--- a/deno/config.ts
+++ b/deno/config.ts
@@ -5,7 +5,9 @@ let func
 
 try {
   func = await import(functionURL)
-} catch {
+} catch (error) {
+  console.error(error)
+
   Deno.exit(exitCodes.ImportError)
 }
 
@@ -31,7 +33,9 @@ try {
   const result = JSON.stringify(config)
 
   await Deno.writeTextFile(new URL(collectorURL), result)
-} catch {
+} catch (error) {
+  console.error(error)
+
   Deno.exit(exitCodes.SerializationError)
 }
 

--- a/node/config.ts
+++ b/node/config.ts
@@ -49,6 +49,7 @@ export const getFunctionConfig = async (func: EdgeFunction, deno: DenoBridge, lo
   const { exitCode, stderr, stdout } = await deno.run(
     [
       'run',
+      '--allow-net',
       '--allow-read',
       `--allow-write=${collector.path}`,
       '--quiet',
@@ -87,7 +88,7 @@ const logConfigError = (func: EdgeFunction, exitCode: number, stderr: string, lo
   switch (exitCode) {
     case ConfigExitCode.ImportError:
       log.user(`Could not load edge function at '${func.path}'`)
-      log.system(stderr)
+      log.user(stderr)
 
       break
 


### PR DESCRIPTION
Follow-up to #133. We need the `--allow-net` flag when running the `config` function, otherwise remote specifiers cannot be resolved.