### PR TITLE
feat: support JSX and TSX in edge functions

### DIFF
--- a/node/finder.ts
+++ b/node/finder.ts
@@ -8,9 +8,16 @@ const ALLOWED_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx'])
 
 const findFunctionInDirectory = async (directory: string): Promise<EdgeFunction | undefined> => {
   const name = basename(directory)
-  const candidatePaths = [`${name}.js`, `index.js`, `${name}.ts`, `index.ts`].map((filename) =>
-    join(directory, filename),
-  )
+  const candidatePaths = [
+    `${name}.js`,
+    `index.js`,
+    `${name}.ts`,
+    `index.ts`,
+    `${name}.jsx`,
+    `index.jsx`,
+    `${name}.tsx`,
+    `index.tsx`,
+  ].map((filename) => join(directory, filename))
 
   let functionPath
 

--- a/node/finder.ts
+++ b/node/finder.ts
@@ -8,16 +8,9 @@ const ALLOWED_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx'])
 
 const findFunctionInDirectory = async (directory: string): Promise<EdgeFunction | undefined> => {
   const name = basename(directory)
-  const candidatePaths = [
-    `${name}.js`,
-    `index.js`,
-    `${name}.ts`,
-    `index.ts`,
-    `${name}.jsx`,
-    `index.jsx`,
-    `${name}.tsx`,
-    `index.tsx`,
-  ].map((filename) => join(directory, filename))
+  const candidatePaths = [...ALLOWED_EXTENSIONS]
+    .flatMap((extension) => [`${name}${extension}`, `index${extension}`])
+    .map((filename) => join(directory, filename))
 
   let functionPath
 

--- a/node/finder.ts
+++ b/node/finder.ts
@@ -4,7 +4,7 @@ import { basename, extname, join } from 'path'
 import { EdgeFunction } from './edge_function.js'
 import { nonNullable } from './utils/non_nullable.js'
 
-const ALLOWED_EXTENSIONS = new Set(['.js', '.ts'])
+const ALLOWED_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx'])
 
 const findFunctionInDirectory = async (directory: string): Promise<EdgeFunction | undefined> => {
   const name = basename(directory)


### PR DESCRIPTION
**Which problem is this pull request solving?**

Adds support for .jsx and .tsx entrypoints in edge functions

**Describe the solution you've chosen**

Deno includes out of the box support for jsx and tsx. However edge bundler doesn't recognise these files, so they can't be used for edge functions at the moment. This PR adds .tsx and .jsx to the list of allowed extensions. It allows things like this:

```tsx
import React from "https://esm.sh/react@18";
import { renderToReadableStream } from "https://esm.sh/v96/react-dom@18.2.0/deno/server.js";

export default async function handler(req: Request) {
  const url = new URL(req.url);
  const username = url.searchParams.get("username");

  if (!username) {
    url.searchParams.set("username", "netlify");
    return Response.redirect(url.toString(), 302);
  }

  const controller = new AbortController();
  let didError = false;
  try {
    const stream = await renderToReadableStream(
      <html>
        <title>Hello</title>
        <body>
          <h1>Hello {username}</h1>
        </body>
      </html>,
      {
        signal: controller.signal,
        onError(error: unknown) {
          didError = true;
          console.error(error);
        },
      },
    );

    return new Response(stream, {
      status: didError ? 500 : 200,
      headers: { "Content-Type": "text/html" },
    });
  } catch (error) {
    return new Response(
      "<!doctype html><p>Something went wrong</p>",
      {
        status: 500,
        headers: { "Content-Type": "text/html" },
      },
    );
  }
}
```

**Describe alternatives you've considered**

Importing a JSX file into a separate js or ts entrypoint

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**
![so im basically very smol](https://user-images.githubusercontent.com/213306/195597504-716f26e5-1fe2-449d-b227-b95b72238f69.png)
