### PR TITLE
feat: add support for post-cache routes

### DIFF
--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -147,7 +147,7 @@ test('Ignores function paths from the in-source `config` function if the feature
   })
   const generatedFiles = await fs.readdir(tmpDir.path)
 
-  expect(result.functions.length).toBe(4)
+  expect(result.functions.length).toBe(6)
   expect(generatedFiles.length).toBe(2)
 
   const manifestFile = await fs.readFile(resolve(tmpDir.path, 'manifest.json'), 'utf8')
@@ -185,22 +185,26 @@ test('Loads function paths from the in-source `config` function', async () => {
   })
   const generatedFiles = await fs.readdir(tmpDir.path)
 
-  expect(result.functions.length).toBe(4)
+  expect(result.functions.length).toBe(6)
   expect(generatedFiles.length).toBe(2)
 
   const manifestFile = await fs.readFile(resolve(tmpDir.path, 'manifest.json'), 'utf8')
   const manifest = JSON.parse(manifestFile)
-  const { bundles, routes } = manifest
+  const { bundles, routes, post_cache_routes: postCacheRoutes } = manifest
 
   expect(bundles.length).toBe(1)
   expect(bundles[0].format).toBe('eszip2')
   expect(generatedFiles.includes(bundles[0].asset)).toBe(true)
 
-  expect(routes.length).toBe(4)
+  expect(routes.length).toBe(5)
   expect(routes[0]).toEqual({ function: 'framework-func2', pattern: '^/framework-func2/?$' })
   expect(routes[1]).toEqual({ function: 'user-func2', pattern: '^/user-func2/?$' })
   expect(routes[2]).toEqual({ function: 'framework-func1', pattern: '^/framework-func1/?$' })
   expect(routes[3]).toEqual({ function: 'user-func1', pattern: '^/user-func1/?$' })
+  expect(routes[4]).toEqual({ function: 'user-func3', pattern: '^/user-func3/?$' })
+
+  expect(postCacheRoutes.length).toBe(1)
+  expect(postCacheRoutes[0]).toEqual({ function: 'user-func4', pattern: '^/user-func4/?$' })
 
   await fs.rmdir(tmpDir.path, { recursive: true })
 })

--- a/node/config.ts
+++ b/node/config.ts
@@ -23,8 +23,8 @@ enum ConfigExitCode {
 
 // eslint-disable-next-line no-shadow
 export const enum Mode {
-  BeforeCache = 'before_cache',
-  AfterCache = 'after_cache',
+  BeforeCache = 'before-cache',
+  AfterCache = 'after-cache',
 }
 
 export interface FunctionConfig {

--- a/node/config.ts
+++ b/node/config.ts
@@ -20,7 +20,14 @@ enum ConfigExitCode {
   SerializationError,
 }
 
+// eslint-disable-next-line no-shadow
+export const enum Mode {
+  BeforeCache = 'before_cache',
+  AfterCache = 'after_cache',
+}
+
 export interface FunctionConfig {
+  mode?: Mode
   path?: string
 }
 

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -2,6 +2,7 @@ import { FunctionConfig } from './config.js'
 
 interface BaseDeclaration {
   function: string
+  mode?: string
   name?: string
 }
 
@@ -31,7 +32,7 @@ export const getDeclarationsFromConfig = (
     if (path) {
       functionsVisited.add(declaration.function)
 
-      declarations.push({ function: declaration.function, path })
+      declarations.push({ ...declaration, path })
     } else {
       declarations.push(declaration)
     }
@@ -40,10 +41,10 @@ export const getDeclarationsFromConfig = (
   // Finally, we must create declarations for functions that are not declared
   // in the TOML at all.
   for (const name in functionsConfig) {
-    const { path } = functionsConfig[name]
+    const { path, ...config } = functionsConfig[name]
 
     if (!functionsVisited.has(name) && path) {
-      declarations.push({ function: name, path })
+      declarations.push({ ...config, function: name, path })
     }
   }
 

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -117,7 +117,7 @@ test('Generates a manifest with pre and post-cache routes', () => {
   const declarations = [
     { function: 'func-1', path: '/f1' },
     { function: 'func-2', mode: 'not_a_supported_mode', path: '/f2' },
-    { function: 'func-3', mode: 'after_cache', path: '/f3' },
+    { function: 'func-3', mode: 'after-cache', path: '/f3' },
   ]
   const manifest = generateManifest({ bundles: [bundle1, bundle2], declarations, functions })
 

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -97,3 +97,42 @@ test('Generates a manifest without bundles', () => {
   expect(manifest.routes).toEqual(expectedRoutes)
   expect(manifest.bundler_version).toBe(env.npm_package_version as string)
 })
+
+test('Generates a manifest with pre and post-cache routes', () => {
+  const bundle1 = {
+    extension: '.ext1',
+    format: 'format1',
+    hash: '123456',
+  }
+  const bundle2 = {
+    extension: '.ext2',
+    format: 'format2',
+    hash: '654321',
+  }
+  const functions = [
+    { name: 'func-1', path: '/path/to/func-1.ts' },
+    { name: 'func-2', path: '/path/to/func-2.ts' },
+    { name: 'func-3', path: '/path/to/func-3.ts' },
+  ]
+  const declarations = [
+    { function: 'func-1', path: '/f1' },
+    { function: 'func-2', mode: 'not_a_supported_mode', path: '/f2' },
+    { function: 'func-3', mode: 'after_cache', path: '/f3' },
+  ]
+  const manifest = generateManifest({ bundles: [bundle1, bundle2], declarations, functions })
+
+  const expectedBundles = [
+    { asset: bundle1.hash + bundle1.extension, format: bundle1.format },
+    { asset: bundle2.hash + bundle2.extension, format: bundle2.format },
+  ]
+  const expectedPreCacheRoutes = [
+    { function: 'func-1', name: undefined, pattern: '^/f1/?$' },
+    { function: 'func-2', name: undefined, pattern: '^/f2/?$' },
+  ]
+  const expectedPostCacheRoutes = [{ function: 'func-3', name: undefined, pattern: '^/f3/?$' }]
+
+  expect(manifest.bundles).toEqual(expectedBundles)
+  expect(manifest.routes).toEqual(expectedPreCacheRoutes)
+  expect(manifest.post_cache_routes).toEqual(expectedPostCacheRoutes)
+  expect(manifest.bundler_version).toBe(env.npm_package_version as string)
+})

--- a/test/fixtures/with_config/netlify/edge-functions/user-func3.ts
+++ b/test/fixtures/with_config/netlify/edge-functions/user-func3.ts
@@ -1,0 +1,6 @@
+export default async () => new Response('Hello from user function 3')
+
+export const config = () => ({
+  mode: 'not_a_supported_mode',
+  path: '/user-func3',
+})

--- a/test/fixtures/with_config/netlify/edge-functions/user-func4.ts
+++ b/test/fixtures/with_config/netlify/edge-functions/user-func4.ts
@@ -1,6 +1,6 @@
 export default async () => new Response('Hello from user function 4. I should run after the cache!')
 
 export const config = () => ({
-  mode: 'after_cache',
+  mode: 'after-cache',
   path: '/user-func4',
 })

--- a/test/fixtures/with_config/netlify/edge-functions/user-func4.ts
+++ b/test/fixtures/with_config/netlify/edge-functions/user-func4.ts
@@ -1,0 +1,6 @@
+export default async () => new Response('Hello from user function 4. I should run after the cache!')
+
+export const config = () => ({
+  mode: 'after_cache',
+  path: '/user-func4',
+})


### PR DESCRIPTION
**Which problem is this pull request solving?**

Looks for a `mode` property in a function declaration (either in the TOML or in-source) and if its value is `after_cache`, the route is added to `post_cache_routes` instead of `routes` in the manifest file. This makes the function run after the cache.

**List other issues or pull requests related to this problem**

Internal: https://github.com/netlify/pod-compute/issues/208