### PR TITLE
fix: use import maps in config evaluation

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -20,6 +20,7 @@ module.exports = {
     {
       files: ['node/**/*.test.ts', 'vitest.config.ts'],
       rules: {
+        'max-lines-per-function': 'off',
         'max-statements': 'off',
         'no-magic-numbers': 'off',
       },

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -141,7 +141,7 @@ const bundle = async (
         return {}
       }
 
-      return getFunctionConfig(func, deno, logger)
+      return getFunctionConfig(func, importMap, deno, logger)
     }),
   )
 

--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs'
 import { join, resolve } from 'path'
+import { pathToFileURL } from 'url'
 
 import del from 'del'
 import { stub } from 'sinon'
@@ -12,6 +13,14 @@ import { DenoBridge } from './bridge.js'
 import { bundle } from './bundler.js'
 import { getFunctionConfig } from './config.js'
 import type { Declaration } from './declaration.js'
+import { ImportMap } from './import_map.js'
+
+const importMapFile = {
+  baseURL: new URL('file:///some/path/import-map.json'),
+  imports: {
+    'alias:helper': pathToFileURL(join(fixturesDir, 'helper.ts')).toString(),
+  },
+}
 
 test('`getFunctionConfig` extracts configuration properties from function file', async () => {
   const { path: tmpDir } = await tmp.dir()
@@ -118,6 +127,7 @@ test('`getFunctionConfig` extracts configuration properties from function file',
         name: func.name,
         path,
       },
+      new ImportMap([importMapFile]),
       deno,
       logger,
     )
@@ -144,6 +154,7 @@ test('Ignores function paths from the in-source `config` function if the feature
     featureFlags: {
       edge_functions_produce_eszip: true,
     },
+    importMaps: [importMapFile],
   })
   const generatedFiles = await fs.readdir(tmpDir.path)
 
@@ -182,6 +193,7 @@ test('Loads function paths from the in-source `config` function', async () => {
       edge_functions_config_export: true,
       edge_functions_produce_eszip: true,
     },
+    importMaps: [importMapFile],
   })
   const generatedFiles = await fs.readdir(tmpDir.path)
 

--- a/node/config.ts
+++ b/node/config.ts
@@ -6,6 +6,7 @@ import tmp from 'tmp-promise'
 
 import { DenoBridge } from './bridge.js'
 import { EdgeFunction } from './edge_function.js'
+import { ImportMap } from './import_map.js'
 import { Logger } from './logger.js'
 import { getPackagePath } from './package_json.js'
 
@@ -31,7 +32,7 @@ const getConfigExtractor = () => {
   return configExtractorPath
 }
 
-export const getFunctionConfig = async (func: EdgeFunction, deno: DenoBridge, log: Logger) => {
+export const getFunctionConfig = async (func: EdgeFunction, importMap: ImportMap, deno: DenoBridge, log: Logger) => {
   // The extractor is a Deno script that will import the function and run its
   // `config` export, if one exists.
   const extractorPath = getConfigExtractor()
@@ -53,6 +54,7 @@ export const getFunctionConfig = async (func: EdgeFunction, deno: DenoBridge, lo
       '--allow-read',
       `--allow-write=${collector.path}`,
       '--quiet',
+      `--import-map=${importMap.toDataURL()}`,
       extractorPath,
       pathToFileURL(func.path).href,
       pathToFileURL(collector.path).href,

--- a/test/fixtures/with_config/.netlify/edge-functions/framework-func1.ts
+++ b/test/fixtures/with_config/.netlify/edge-functions/framework-func1.ts
@@ -1,4 +1,10 @@
-export default async () => new Response('Hello from framework function 1')
+import { greet } from 'alias:helper'
+
+export default async () => {
+  const greeting = greet('framework function 1')
+
+  return new Response(greeting)
+}
 
 export const config = () => ({
   path: '/framework-func1',

--- a/test/fixtures/with_config/.netlify/edge-functions/framework-func2.ts
+++ b/test/fixtures/with_config/.netlify/edge-functions/framework-func2.ts
@@ -1,3 +1,5 @@
+import { greet } from 'alias:helper'
+
 export default async () => {
   const greeting = greet('framework function 1')
 

--- a/test/fixtures/with_config/.netlify/edge-functions/framework-func2.ts
+++ b/test/fixtures/with_config/.netlify/edge-functions/framework-func2.ts
@@ -1,7 +1,7 @@
 import { greet } from 'alias:helper'
 
 export default async () => {
-  const greeting = greet('framework function 1')
+  const greeting = greet('framework function 2')
 
   return new Response(greeting)
 }

--- a/test/fixtures/with_config/.netlify/edge-functions/framework-func2.ts
+++ b/test/fixtures/with_config/.netlify/edge-functions/framework-func2.ts
@@ -1,1 +1,5 @@
-export default async () => new Response('Hello from framework function 2')
+export default async () => {
+  const greeting = greet('framework function 1')
+
+  return new Response(greeting)
+}

--- a/test/fixtures/with_config/netlify/edge-functions/user-func1.ts
+++ b/test/fixtures/with_config/netlify/edge-functions/user-func1.ts
@@ -1,4 +1,10 @@
-export default async () => new Response('Hello from user function 1')
+import { greet } from 'alias:helper'
+
+export default async () => {
+  const greeting = greet('user function 1')
+
+  return new Response(greeting)
+}
 
 export const config = () => ({
   path: '/user-func1',

--- a/test/fixtures/with_config/netlify/edge-functions/user-func2.ts
+++ b/test/fixtures/with_config/netlify/edge-functions/user-func2.ts
@@ -1,1 +1,7 @@
-export default async () => new Response('Hello from user function 2')
+import { greet } from 'alias:helper'
+
+export default async () => {
+  const greeting = greet('user function 2')
+
+  return new Response(greeting)
+}


### PR DESCRIPTION
**Which problem is this pull request solving?**

#133 added support for a `config` export, which we evaluate at build time to extract a configuration object. Currently, we're not using any import maps when doing this invocation, any specifiers that we can't process (even if they're not used by the `config` function itself) will throw an error.

This PR addresses that by evaluating the `config` export with the same import maps as the runtime evaluation.