### PR TITLE
fix: run `config` export with `--allow-env`

### DIFF
--- a/node/config.ts
+++ b/node/config.ts
@@ -57,6 +57,7 @@ export const getFunctionConfig = async (func: EdgeFunction, importMap: ImportMap
   const { exitCode, stderr, stdout } = await deno.run(
     [
       'run',
+      '--allow-env',
       '--allow-net',
       '--allow-read',
       `--allow-write=${collector.path}`,

--- a/test/fixtures/with_config/netlify/edge-functions/user-func1.ts
+++ b/test/fixtures/with_config/netlify/edge-functions/user-func1.ts
@@ -1,5 +1,10 @@
 import { greet } from 'alias:helper'
 
+// Accessing `Deno.env` in the global scope
+if (Deno.env.get('FOO')) {
+  // no-op
+}
+
 export default async () => {
   const greeting = greet('user function 1')
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

When invoking the edge function at build time to resolve the `config` export, we should call the Deno CLI with `--allow-env`, otherwise we'll get an error if the function is trying to access `Deno.env` in the global scope.