### PR TITLE
feat: get config in server mode

### DIFF
--- a/node/server/server.test.ts
+++ b/node/server/server.test.ts
@@ -7,25 +7,38 @@ import { test, expect } from 'vitest'
 import { fixturesDir } from '../../test/util.js'
 import { serve } from '../index.js'
 
-test('bundler serving functionality', async () => {
+test('Starts a server and serves requests for edge functions', async () => {
   const port = await getPort()
   const server = await serve({
     port,
   })
+  const functionPath = join(fixturesDir, 'serve_test', 'echo_env.ts')
 
-  const { success } = await server(
-    [
-      {
-        name: 'echo_env',
-        path: join(fixturesDir, 'serve_test', 'echo_env.ts'),
-      },
-    ],
+  const functions = [
+    {
+      name: 'echo_env',
+      path: functionPath,
+    },
+  ]
+  const options = {
+    getFunctionsConfig: true,
+  }
+  const { functionsConfig, graph, success } = await server(
+    functions,
     {
       very_secret_secret: 'i love netlify',
     },
+    options,
   )
-
   expect(success).toBe(true)
+
+  expect(functionsConfig).toEqual([{ path: '/my-function' }])
+
+  const graphEntry = graph?.modules.some(
+    // @ts-expect-error TODO: Module graph is currently not typed
+    ({ kind, mediaType, local }) => kind === 'esm' && mediaType === 'TypeScript' && local === functionPath,
+  )
+  expect(graphEntry).toBe(true)
 
   const response = await fetch(`http://0.0.0.0:${port}/foo`, {
     headers: {

--- a/node/server/server.test.ts
+++ b/node/server/server.test.ts
@@ -4,9 +4,8 @@ import getPort from 'get-port'
 import fetch from 'node-fetch'
 import { test, expect } from 'vitest'
 
-import { fixturesDir } from '../test/util.js'
-
-import { serve } from './index.js'
+import { fixturesDir } from '../../test/util.js'
+import { serve } from '../index.js'
 
 test('bundler serving functionality', async () => {
   const port = await getPort()

--- a/test/fixtures/serve_test/echo_env.ts
+++ b/test/fixtures/serve_test/echo_env.ts
@@ -1,1 +1,7 @@
+import { Config } from 'https://edge.netlify.com'
+
 export default async () => new Response(JSON.stringify(Deno.env.toObject()))
+
+export const config: Config = () => ({
+  path: '/my-function',
+})


### PR DESCRIPTION
**Which problem is this pull request solving?**

To make in-source configuration work with the CLI, we need to parse the function config when in server mode. This PR enables that.