### PR TITLE
fix: remove disallow-code-generation-from-strings flag

### DIFF
--- a/node/server/server.ts
+++ b/node/server/server.ts
@@ -158,13 +158,7 @@ const serve = async ({
   // Creating an ImportMap instance with any import maps supplied by the user,
   // if any.
   const importMap = new ImportMap(importMaps)
-  const flags = [
-    '--allow-all',
-    '--unstable',
-    `--import-map=${importMap.toDataURL()}`,
-    '--v8-flags=--disallow-code-generation-from-strings',
-    '--no-config',
-  ]
+  const flags = ['--allow-all', '--unstable', `--import-map=${importMap.toDataURL()}`, '--no-config']
 
   if (certificatePath) {
     flags.push(`--cert=${certificatePath}`)


### PR DESCRIPTION
Deno version 1.27.1 does not work with this flag and as it turned out it was introduced to disallow `eval()` in dev/cli, because it wasn't allowed in prod. 

Now eval() is available in prod so we should remove this flag.
