### PR TITLE
fix: load .wasm file locally

### DIFF
--- a/deno/lib/stage2.ts
+++ b/deno/lib/stage2.ts
@@ -1,4 +1,5 @@
-import { build, LoadResponse } from 'https://deno.land/x/eszip@v0.28.0/mod.ts'
+// important to load this as a local file, so that vendored .wasm file is used
+import { build, LoadResponse } from '../vendor/deno.land/x/eszip@v0.28.0/mod.ts'
 
 import * as path from 'https://deno.land/std@0.127.0/path/mod.ts'
 


### PR DESCRIPTION
context: https://netlify.slack.com/archives/C02BUDF7A4B/p1667667057977549

right now, even though we were using the vendored .ts files of `x/eszip`, the generated loader `eszip_wasm.generated.js` is still fetching the WASM file via HTTPS: https://github.com/netlify/edge-bundler/blob/4e2414a0b6dcf7eab8ce40ca2a0fd658661c86fd/deno/vendor/deno.land/x/eszip%40v0.28.0/eszip_wasm.generated.js#L552

I believe this is a bug in that file, so I'll open an issue there. But until that's fixed, this PR contains a fix for it. Loading the file via a local import will result in this branch being called: https://github.com/netlify/edge-bundler/blob/4e2414a0b6dcf7eab8ce40ca2a0fd658661c86fd/deno/vendor/deno.land/x/eszip%40v0.28.0/eszip_wasm.generated.js#L533-L546