### PR TITLE
fix: remove flag edge_functions_use_vendored_eszip

### DIFF
--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -101,7 +101,6 @@ test('Uses the vendored eszip module instead of fetching it from deno.land', asy
     basePath: fixturesDir,
     featureFlags: {
       edge_functions_produce_eszip: true,
-      edge_functions_use_vendored_eszip: true,
     },
     importMaps: [
       {

--- a/node/feature_flags.ts
+++ b/node/feature_flags.ts
@@ -2,7 +2,6 @@ const defaultFlags: Record<string, boolean> = {
   edge_functions_cache_deno_dir: false,
   edge_functions_config_export: false,
   edge_functions_produce_eszip: false,
-  edge_functions_use_vendored_eszip: false,
 }
 
 type FeatureFlag = keyof typeof defaultFlags

--- a/node/formats/eszip.ts
+++ b/node/formats/eszip.ts
@@ -27,7 +27,6 @@ const bundleESZIP = async ({
   debug,
   deno,
   distDirectory,
-  featureFlags,
   functions,
   importMap,
 }: BundleESZIPOptions): Promise<Bundle> => {
@@ -48,9 +47,7 @@ const bundleESZIP = async ({
 
   // To actually vendor the eszip module, we need to supply the import map that
   // redirects `https://deno.land/` URLs to the local files.
-  if (featureFlags.edge_functions_use_vendored_eszip) {
-    flags.push(`--import-map=${bundlerImportMap}`)
-  }
+  flags.push(`--import-map=${bundlerImportMap}`)
 
   try {
     await deno.run(['run', ...flags, bundler, JSON.stringify(payload)], { pipeOutput: true })


### PR DESCRIPTION
flag is fully rolled out: https://github.com/netlify/edge-bundler/pull/187#issue-1441699898