### PR TITLE
feat: add support for custom layers

### DIFF
--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -14,6 +14,7 @@ import { findFunctions } from './finder.js'
 import { bundle as bundleESZIP } from './formats/eszip.js'
 import { bundle as bundleJS } from './formats/javascript.js'
 import { ImportMap, ImportMapFile } from './import_map.js'
+import { Layer } from './layer.js'
 import { getLogger, LogFunction } from './logger.js'
 import { writeManifest } from './manifest.js'
 import { ensureLatestTypes } from './types.js'
@@ -25,6 +26,7 @@ interface BundleOptions {
   distImportMapPath?: string
   featureFlags?: FeatureFlags
   importMaps?: ImportMapFile[]
+  layers?: Layer[]
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   systemLogger?: LogFunction

--- a/node/layer.ts
+++ b/node/layer.ts
@@ -1,0 +1,4 @@
+export interface Layer {
+  flag: string
+  name: string
+}

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -136,3 +136,32 @@ test('Generates a manifest with pre and post-cache routes', () => {
   expect(manifest.post_cache_routes).toEqual(expectedPostCacheRoutes)
   expect(manifest.bundler_version).toBe(env.npm_package_version as string)
 })
+
+test('Generates a manifest with layers', () => {
+  const functions = [
+    { name: 'func-1', path: '/path/to/func-1.ts' },
+    { name: 'func-2', path: '/path/to/func-2.ts' },
+  ]
+  const declarations = [
+    { function: 'func-1', path: '/f1/*' },
+    { function: 'func-2', path: '/f2/*' },
+  ]
+  const expectedRoutes = [
+    { function: 'func-1', pattern: '^/f1/.*/?$' },
+    { function: 'func-2', pattern: '^/f2/.*/?$' },
+  ]
+  const layers = [
+    {
+      name: 'onion',
+      flag: 'edge_functions_onion_layer',
+    },
+  ]
+  const manifest1 = generateManifest({ bundles: [], declarations, functions })
+  const manifest2 = generateManifest({ bundles: [], declarations, functions, layers })
+
+  expect(manifest1.routes).toEqual(expectedRoutes)
+  expect(manifest1.layers).toEqual([])
+
+  expect(manifest2.routes).toEqual(expectedRoutes)
+  expect(manifest2.layers).toEqual(layers)
+})

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -7,13 +7,15 @@ import type { Bundle } from './bundle.js'
 import { Cache } from './config.js'
 import type { Declaration } from './declaration.js'
 import { EdgeFunction } from './edge_function.js'
+import { Layer } from './layer.js'
 import { getPackageVersion } from './package_json.js'
 import { nonNullable } from './utils/non_nullable.js'
 
 interface GenerateManifestOptions {
   bundles?: Bundle[]
-  functions: EdgeFunction[]
   declarations?: Declaration[]
+  functions: EdgeFunction[]
+  layers?: Layer[]
 }
 
 /* eslint-disable camelcase */
@@ -22,6 +24,7 @@ interface Manifest {
   bundles: { asset: string; format: string }[]
   routes: { function: string; name?: string; pattern: string }[]
   post_cache_routes: { function: string; name?: string; pattern: string }[]
+  layers: { name: string; flag: string }[]
 }
 /* eslint-enable camelcase */
 
@@ -31,7 +34,7 @@ interface Route {
   pattern: string
 }
 
-const generateManifest = ({ bundles = [], declarations = [], functions }: GenerateManifestOptions) => {
+const generateManifest = ({ bundles = [], declarations = [], functions, layers = [] }: GenerateManifestOptions) => {
   const preCacheRoutes: Route[] = []
   const postCacheRoutes: Route[] = []
 
@@ -65,6 +68,7 @@ const generateManifest = ({ bundles = [], declarations = [], functions }: Genera
     routes: preCacheRoutes.filter(nonNullable),
     post_cache_routes: postCacheRoutes.filter(nonNullable),
     bundler_version: getPackageVersion(),
+    layers,
   }
 
   return manifest
@@ -92,10 +96,17 @@ interface WriteManifestOptions {
   declarations: Declaration[]
   distDirectory: string
   functions: EdgeFunction[]
+  layers?: Layer[]
 }
 
-const writeManifest = async ({ bundles, declarations = [], distDirectory, functions }: WriteManifestOptions) => {
-  const manifest = generateManifest({ bundles, declarations, functions })
+const writeManifest = async ({
+  bundles,
+  declarations = [],
+  distDirectory,
+  functions,
+  layers,
+}: WriteManifestOptions) => {
+  const manifest = generateManifest({ bundles, declarations, functions, layers })
   const manifestPath = join(distDirectory, 'manifest.json')
 
   await fs.writeFile(manifestPath, JSON.stringify(manifest))


### PR DESCRIPTION
Adds a new `layers` optional parameter to the `bundle` entry point, which writes custom layer information to the manifest.

Support for the `local_url` property and the `serve` entry point will come in a separate PR.