### PR TITLE
feat: add `layer:` prefix to ESZIP loader

### DIFF
--- a/deno/lib/consts.ts
+++ b/deno/lib/consts.ts
@@ -1,4 +1,5 @@
-export const PUBLIC_SPECIFIER = "netlify:edge";
-export const STAGE1_SPECIFIER = "netlify:bootstrap-stage1";
-export const STAGE2_SPECIFIER = "netlify:bootstrap-stage2";
-export const virtualRoot = "file:///root/";
+export const CUSTOM_LAYER_PREFIX = 'layer:'
+export const PUBLIC_SPECIFIER = 'netlify:edge'
+export const STAGE1_SPECIFIER = 'netlify:bootstrap-stage1'
+export const STAGE2_SPECIFIER = 'netlify:bootstrap-stage2'
+export const virtualRoot = 'file:///root/'

--- a/deno/lib/stage2.ts
+++ b/deno/lib/stage2.ts
@@ -88,6 +88,9 @@ const stage2Loader = (basePath: string, functions: InputFunction[]) => {
 const writeStage2 = async ({ basePath, destPath, functions, importMapURL }: WriteStage2Options) => {
   const loader = stage2Loader(basePath, functions)
   const bytes = await build([STAGE2_SPECIFIER], loader, importMapURL)
+  const directory = path.dirname(destPath)
+
+  await Deno.mkdir(directory, { recursive: true })
 
   return await Deno.writeFile(destPath, bytes)
 }

--- a/deno/lib/stage2.ts
+++ b/deno/lib/stage2.ts
@@ -3,7 +3,7 @@ import { build, LoadResponse } from 'https://deno.land/x/eszip@v0.28.0/mod.ts'
 import * as path from 'https://deno.land/std@0.127.0/path/mod.ts'
 
 import type { InputFunction, WriteStage2Options } from '../../shared/stage2.ts'
-import { PUBLIC_SPECIFIER, STAGE2_SPECIFIER, virtualRoot } from './consts.ts'
+import { CUSTOM_LAYER_PREFIX, PUBLIC_SPECIFIER, STAGE2_SPECIFIER, virtualRoot } from './consts.ts'
 import { inlineModule, loadFromVirtualRoot, loadWithRetry } from './common.ts'
 
 interface FunctionReference {
@@ -70,7 +70,7 @@ const stage2Loader = (basePath: string, functions: InputFunction[]) => {
       return inlineModule(specifier, stage2Entry)
     }
 
-    if (specifier === PUBLIC_SPECIFIER) {
+    if (specifier === PUBLIC_SPECIFIER || specifier.startsWith(CUSTOM_LAYER_PREFIX)) {
       return {
         kind: 'external',
         specifier,

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -87,6 +87,7 @@ const bundle = async (
     distImportMapPath,
     featureFlags: inputFeatureFlags,
     importMaps,
+    layers,
     onAfterDownload,
     onBeforeDownload,
     systemLogger,
@@ -162,6 +163,7 @@ const bundle = async (
     declarations,
     distDirectory,
     functions,
+    layers,
   })
 
   if (distImportMapPath) {

--- a/test/fixtures/with_layers/functions/func1.ts
+++ b/test/fixtures/with_layers/functions/func1.ts
@@ -1,0 +1,3 @@
+import { handleRequest } from 'layer:test'
+
+export default (req: Request) => handleRequest(req)


### PR DESCRIPTION
This should've been part of #198, but I forgot. We need to tell the ESZIP loader to treat any specifiers that start with `layer:` as dangling imports.