### PR TITLE
feat!: move internal config file to Edge Bundler

### DIFF
--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -1,7 +1,6 @@
 import { promises as fs } from 'fs'
 import { join, resolve } from 'path'
 import process from 'process'
-import { pathToFileURL } from 'url'
 
 import { deleteAsync } from 'del'
 import tmp from 'tmp-promise'
@@ -185,14 +184,7 @@ test('Uses the cache directory as the `DENO_DIR` value if the `edge_functions_ca
   const options: BundleOptions = {
     basePath: fixturesDir,
     cacheDirectory: cacheDir.path,
-    importMaps: [
-      {
-        baseURL: pathToFileURL(join(fixturesDir, 'import-map.json')),
-        imports: {
-          'alias:helper': pathToFileURL(join(fixturesDir, 'helper.ts')).toString(),
-        },
-      },
-    ],
+    configPath: join(sourceDirectory, 'config.json'),
   }
 
   // Run #1, feature flag off: The directory should not be populated.
@@ -239,17 +231,10 @@ test('Supports import maps with relative paths', async () => {
   ]
   const result = await bundle([sourceDirectory], tmpDir.path, declarations, {
     basePath: fixturesDir,
+    configPath: join(sourceDirectory, 'config.json'),
     featureFlags: {
       edge_functions_produce_eszip: true,
     },
-    importMaps: [
-      {
-        baseURL: pathToFileURL(join(fixturesDir, 'import-map.json')),
-        imports: {
-          'alias:helper': './helper.ts',
-        },
-      },
-    ],
   })
   const generatedFiles = await fs.readdir(tmpDir.path)
 
@@ -314,17 +299,10 @@ test('Ignores any user-defined `deno.json` files', async () => {
   expect(() =>
     bundle([join(fixtureDir, 'functions')], tmpDir.path, declarations, {
       basePath: fixturesDir,
+      configPath: join(fixtureDir, 'functions', 'config.json'),
       featureFlags: {
         edge_functions_produce_eszip: true,
       },
-      importMaps: [
-        {
-          baseURL: pathToFileURL(join(fixturesDir, 'import-map.json')),
-          imports: {
-            'alias:helper': pathToFileURL(join(fixturesDir, 'helper.ts')).toString(),
-          },
-        },
-      ],
     }),
   ).not.toThrow()
 
@@ -382,14 +360,6 @@ test('Loads declarations and import maps from the deploy configuration', async (
     featureFlags: {
       edge_functions_produce_eszip: true,
     },
-    importMaps: [
-      {
-        baseURL: pathToFileURL(join(fixtureDir, 'import-map.json')),
-        imports: {
-          'alias:helper1': pathToFileURL(join(fixtureDir, 'util.ts')).toString(),
-        },
-      },
-    ],
   })
   const generatedFiles = await fs.readdir(tmpDir.path)
 

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -119,9 +119,12 @@ const bundle = async (
   // exists.
   const deployConfig = await loadDeployConfig(configPath, logger)
 
-  // Creating an ImportMap instance with any import maps supplied by the user,
-  // if any.
-  const importMap = new ImportMap(deployConfig.importMap ? [deployConfig.importMap] : [])
+  const importMap = new ImportMap()
+
+  if (deployConfig.importMap) {
+    importMap.add(deployConfig.importMap)
+  }
+
   const functions = await findFunctions(sourceDirectories)
   const functionBundle = await createBundle({
     basePath,

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -14,11 +14,10 @@ import { FeatureFlags, getFlags } from './feature_flags.js'
 import { findFunctions } from './finder.js'
 import { bundle as bundleESZIP } from './formats/eszip.js'
 import { bundle as bundleJS } from './formats/javascript.js'
-import { ImportMap, ImportMapFile } from './import_map.js'
+import { ImportMap } from './import_map.js'
 import { getLogger, LogFunction } from './logger.js'
 import { writeManifest } from './manifest.js'
 import { ensureLatestTypes } from './types.js'
-import { nonNullable } from './utils/non_nullable.js'
 
 interface BundleOptions {
   basePath?: string
@@ -27,7 +26,6 @@ interface BundleOptions {
   debug?: boolean
   distImportMapPath?: string
   featureFlags?: FeatureFlags
-  importMaps?: ImportMapFile[]
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   systemLogger?: LogFunction
@@ -88,7 +86,6 @@ const bundle = async (
     debug,
     distImportMapPath,
     featureFlags: inputFeatureFlags,
-    importMaps = [],
     onAfterDownload,
     onBeforeDownload,
     systemLogger,
@@ -124,7 +121,7 @@ const bundle = async (
 
   // Creating an ImportMap instance with any import maps supplied by the user,
   // if any.
-  const importMap = new ImportMap([...importMaps, deployConfig.importMap].filter(nonNullable))
+  const importMap = new ImportMap(deployConfig.importMap ? [deployConfig.importMap] : [])
   const functions = await findFunctions(sourceDirectories)
   const functionBundle = await createBundle({
     basePath,

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -8,25 +8,26 @@ import { DenoBridge, DenoOptions, OnAfterDownloadHook, OnBeforeDownloadHook } fr
 import type { Bundle } from './bundle.js'
 import { FunctionConfig, getFunctionConfig } from './config.js'
 import { Declaration, getDeclarationsFromConfig } from './declaration.js'
+import { load as loadDeployConfig } from './deploy_config.js'
 import { EdgeFunction } from './edge_function.js'
 import { FeatureFlags, getFlags } from './feature_flags.js'
 import { findFunctions } from './finder.js'
 import { bundle as bundleESZIP } from './formats/eszip.js'
 import { bundle as bundleJS } from './formats/javascript.js'
 import { ImportMap, ImportMapFile } from './import_map.js'
-import { Layer } from './layer.js'
 import { getLogger, LogFunction } from './logger.js'
 import { writeManifest } from './manifest.js'
 import { ensureLatestTypes } from './types.js'
+import { nonNullable } from './utils/non_nullable.js'
 
 interface BundleOptions {
   basePath?: string
   cacheDirectory?: string
+  configPath?: string
   debug?: boolean
   distImportMapPath?: string
   featureFlags?: FeatureFlags
   importMaps?: ImportMapFile[]
-  layers?: Layer[]
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   systemLogger?: LogFunction
@@ -83,11 +84,11 @@ const bundle = async (
   {
     basePath: inputBasePath,
     cacheDirectory,
+    configPath,
     debug,
     distImportMapPath,
     featureFlags: inputFeatureFlags,
-    importMaps,
-    layers,
+    importMaps = [],
     onAfterDownload,
     onBeforeDownload,
     systemLogger,
@@ -117,9 +118,13 @@ const bundle = async (
   // to create the bundle artifacts and rename them later.
   const buildID = uuidv4()
 
+  // Loading any configuration options from the deploy configuration API, if it
+  // exists.
+  const deployConfig = await loadDeployConfig(configPath, logger)
+
   // Creating an ImportMap instance with any import maps supplied by the user,
   // if any.
-  const importMap = new ImportMap(importMaps)
+  const importMap = new ImportMap([...importMaps, deployConfig.importMap].filter(nonNullable))
   const functions = await findFunctions(sourceDirectories)
   const functionBundle = await createBundle({
     basePath,
@@ -154,16 +159,16 @@ const bundle = async (
     {} as Record<string, FunctionConfig>,
   )
 
-  // Creating a final declarations array by combining the TOML entries with the
-  // function configuration objects.
-  const declarations = getDeclarationsFromConfig(tomlDeclarations, functionsWithConfig)
+  // Creating a final declarations array by combining the TOML file with the
+  // deploy configuration API and the in-source configuration.
+  const declarations = getDeclarationsFromConfig(tomlDeclarations, functionsWithConfig, deployConfig)
 
   const manifest = await writeManifest({
     bundles: [functionBundle],
     declarations,
     distDirectory,
     functions,
-    layers,
+    layers: deployConfig.layers,
   })
 
   if (distImportMapPath) {

--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -153,10 +153,10 @@ test('Ignores function paths from the in-source `config` function if the feature
   const declarations: Declaration[] = []
   const result = await bundle([internalDirectory, userDirectory], tmpDir.path, declarations, {
     basePath: fixturesDir,
+    configPath: join(internalDirectory, 'config.json'),
     featureFlags: {
       edge_functions_produce_eszip: true,
     },
-    importMaps: [importMapFile],
   })
   const generatedFiles = await fs.readdir(tmpDir.path)
 
@@ -191,11 +191,11 @@ test('Loads function paths from the in-source `config` function', async () => {
   ]
   const result = await bundle([internalDirectory, userDirectory], tmpDir.path, declarations, {
     basePath: fixturesDir,
+    configPath: join(internalDirectory, 'config.json'),
     featureFlags: {
       edge_functions_config_export: true,
       edge_functions_produce_eszip: true,
     },
-    importMaps: [importMapFile],
   })
   const generatedFiles = await fs.readdir(tmpDir.path)
 

--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -3,6 +3,12 @@ import { test, expect } from 'vitest'
 import { FunctionConfig } from './config.js'
 import { getDeclarationsFromConfig } from './declaration.js'
 
+// TODO: Add tests with the deploy config.
+const deployConfig = {
+  declarations: [],
+  layers: [],
+}
+
 test('In source config takes precedence over netlify.toml config', () => {
   const tomlConfig = [
     { function: 'geolocation', path: '/geo', cache: 'off' },
@@ -19,7 +25,7 @@ test('In source config takes precedence over netlify.toml config', () => {
     { function: 'json', path: '/json', cache: 'off' },
   ]
 
-  const declarations = getDeclarationsFromConfig(tomlConfig, funcConfig)
+  const declarations = getDeclarationsFromConfig(tomlConfig, funcConfig, deployConfig)
 
   expect(declarations).toEqual(expectedDeclarations)
 })
@@ -40,7 +46,7 @@ test("Declarations don't break if no in source config is provided", () => {
     { function: 'json', path: '/json', cache: 'manual' },
   ]
 
-  const declarations = getDeclarationsFromConfig(tomlConfig, funcConfig)
+  const declarations = getDeclarationsFromConfig(tomlConfig, funcConfig, deployConfig)
 
   expect(declarations).toEqual(expectedDeclarations)
 })
@@ -63,10 +69,9 @@ test('In source config works independent of the netlify.toml file if a path is d
 
   const expectedDeclarationsWithoutISCPath = [{ function: 'geolocation', path: '/geo', cache: 'off' }]
 
-  const declarationsWithISCPath = getDeclarationsFromConfig(tomlConfig, funcConfigWithPath)
-
-  const declarationsWithoutISCPath = getDeclarationsFromConfig(tomlConfig, funcConfigWithoutPath)
-
+  const declarationsWithISCPath = getDeclarationsFromConfig(tomlConfig, funcConfigWithPath, deployConfig)
   expect(declarationsWithISCPath).toEqual(expectedDeclarationsWithISCPath)
+
+  const declarationsWithoutISCPath = getDeclarationsFromConfig(tomlConfig, funcConfigWithoutPath, deployConfig)
   expect(declarationsWithoutISCPath).toEqual(expectedDeclarationsWithoutISCPath)
 })

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -1,4 +1,5 @@
 import { FunctionConfig } from './config.js'
+import type { DeployConfig } from './deploy_config.js'
 
 interface BaseDeclaration {
   cache?: string
@@ -19,14 +20,16 @@ type Declaration = DeclarationWithPath | DeclarationWithPattern
 export const getDeclarationsFromConfig = (
   tomlDeclarations: Declaration[],
   functionsConfig: Record<string, FunctionConfig>,
+  deployConfig: DeployConfig,
 ) => {
   const declarations: Declaration[] = []
   const functionsVisited: Set<string> = new Set()
 
-  // We start by iterating over all the TOML declarations. For any declaration
-  // for which we also have a function configuration object, we replace the
-  // path because that object takes precedence.
-  for (const declaration of tomlDeclarations) {
+  // We start by iterating over all the declarations in the TOML file and in
+  // the deploy configuration file. For any declaration for which we also have
+  // a function configuration object, we replace the path because that object
+  // takes precedence.
+  for (const declaration of [...tomlDeclarations, ...deployConfig.declarations]) {
     const { path } = functionsConfig[declaration.function] ?? {}
 
     if (path) {

--- a/node/deploy_config.test.ts
+++ b/node/deploy_config.test.ts
@@ -1,0 +1,60 @@
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { cwd } from 'process'
+import { pathToFileURL } from 'url'
+
+import tmp from 'tmp-promise'
+import { test, expect } from 'vitest'
+
+import { load } from './deploy_config.js'
+import { getLogger } from './logger.js'
+
+const logger = getLogger(console.log)
+
+test('Returns an empty config object if there is no file at the given path', async () => {
+  const mockPath = join(cwd(), 'some-directory', `a-file-that-does-not-exist-${Date.now()}.json`)
+  const config = await load(mockPath, logger)
+
+  expect(config.declarations).toEqual([])
+  expect(config.layers).toEqual([])
+})
+
+test('Returns a config object with declarations, layers, and import map', async () => {
+  const importMapFile = await tmp.file()
+  const importMap = {
+    imports: {
+      'https://deno.land/': 'https://black.hole/',
+    },
+  }
+
+  await fs.writeFile(importMapFile.path, JSON.stringify(importMap))
+
+  const configFile = await tmp.file()
+  const config = {
+    functions: [
+      {
+        function: 'func1',
+        path: '/func1',
+      },
+    ],
+    layers: [
+      {
+        name: 'layer1',
+        flag: 'edge_functions_layer1_url',
+        local: 'https://some-url.netlify.app/mod.ts',
+      },
+    ],
+    import_map: importMapFile.path,
+    version: 1,
+  }
+
+  await fs.writeFile(configFile.path, JSON.stringify(config))
+
+  const parsedConfig = await load(configFile.path, logger)
+
+  expect(parsedConfig.declarations).toEqual(config.functions)
+  expect(parsedConfig.layers).toEqual(config.layers)
+  expect(parsedConfig.importMap).toBeTruthy()
+  expect(parsedConfig.importMap?.baseURL).toEqual(pathToFileURL(importMapFile.path))
+  expect(parsedConfig.importMap?.imports).toEqual(importMap.imports)
+})

--- a/node/deploy_config.ts
+++ b/node/deploy_config.ts
@@ -23,17 +23,21 @@ export interface DeployConfig {
 }
 
 export const load = async (path: string | undefined, logger: Logger): Promise<DeployConfig> => {
-  if (path !== undefined) {
-    try {
-      const data = await fs.readFile(path, 'utf8')
-      const config = JSON.parse(data) as DeployConfigFile
+  if (path === undefined) {
+    return {
+      declarations: [],
+      layers: [],
+    }
+  }
 
-      return parse(config, path)
-    } catch (error) {
-      // eslint-disable-next-line max-depth
-      if (isNodeError(error) && error.code !== 'ENOENT') {
-        logger.system('Error while parsing internal edge functions manifest:', error)
-      }
+  try {
+    const data = await fs.readFile(path, 'utf8')
+    const config = JSON.parse(data) as DeployConfigFile
+
+    return parse(config, path)
+  } catch (error) {
+    if (isNodeError(error) && error.code !== 'ENOENT') {
+      logger.system('Error while parsing internal edge functions manifest:', error)
     }
   }
 

--- a/node/deploy_config.ts
+++ b/node/deploy_config.ts
@@ -1,0 +1,67 @@
+import { promises as fs } from 'fs'
+import { dirname, resolve } from 'path'
+
+import type { Declaration } from './declaration.js'
+import { ImportMapFile, readFile as readImportMap } from './import_map.js'
+import type { Layer } from './layer.js'
+import type { Logger } from './logger.js'
+import { isNodeError } from './utils/error.js'
+
+/* eslint-disable camelcase */
+interface DeployConfigFile {
+  functions?: Declaration[]
+  import_map?: string
+  layers?: Layer[]
+  version: number
+}
+/* eslint-enable camelcase */
+
+export interface DeployConfig {
+  declarations: Declaration[]
+  importMap?: ImportMapFile
+  layers: Layer[]
+}
+
+export const load = async (path: string | undefined, logger: Logger): Promise<DeployConfig> => {
+  if (path !== undefined) {
+    try {
+      const data = await fs.readFile(path, 'utf8')
+      const config = JSON.parse(data) as DeployConfigFile
+
+      return parse(config, path)
+    } catch (error) {
+      // eslint-disable-next-line max-depth
+      if (isNodeError(error) && error.code !== 'ENOENT') {
+        logger.system('Error while parsing internal edge functions manifest:', error)
+      }
+    }
+  }
+
+  return {
+    declarations: [],
+    layers: [],
+  }
+}
+
+const parse = async (data: DeployConfigFile, path: string): Promise<DeployConfig> => {
+  if (data.version !== 1) {
+    throw new Error(`Unsupported file version: ${data.version}`)
+  }
+
+  const config = {
+    declarations: data.functions ?? [],
+    layers: data.layers ?? [],
+  }
+
+  if (data.import_map) {
+    const importMapPath = resolve(dirname(path), data.import_map)
+    const importMap = await readImportMap(importMapPath)
+
+    return {
+      ...config,
+      importMap,
+    }
+  }
+
+  return config
+}

--- a/node/import_map.ts
+++ b/node/import_map.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer'
 import { promises as fs } from 'fs'
 import { dirname } from 'path'
+import { pathToFileURL } from 'url'
 
 import { parse } from '@import-maps/resolve'
 
@@ -17,7 +18,7 @@ interface ImportMapFile {
 class ImportMap {
   imports: Record<string, URL | null>
 
-  constructor(files: ImportMapFile[] = []) {
+  constructor(files: ImportMapFile[]) {
     let imports: ImportMap['imports'] = {}
 
     files.forEach((file) => {
@@ -67,5 +68,26 @@ class ImportMap {
   }
 }
 
-export { ImportMap }
+const readFile = async (path: string): Promise<ImportMapFile> => {
+  const baseURL = pathToFileURL(path)
+
+  try {
+    const data = await fs.readFile(path, 'utf8')
+    const importMap = JSON.parse(data)
+
+    return {
+      ...importMap,
+      baseURL,
+    }
+  } catch {
+    // no-op
+  }
+
+  return {
+    baseURL,
+    imports: {},
+  }
+}
+
+export { ImportMap, readFile }
 export type { ImportMapFile }

--- a/node/import_map.ts
+++ b/node/import_map.ts
@@ -15,13 +15,34 @@ interface ImportMapFile {
   scopes?: Record<string, Record<string, string>>
 }
 
+// ImportMap can take several import map files and merge them into a final
+// import map object, also adding the internal imports in the right order.
 class ImportMap {
-  imports: Record<string, URL | null>
+  files: ImportMapFile[]
 
-  constructor(files: ImportMapFile[]) {
-    let imports: ImportMap['imports'] = {}
+  constructor(files: ImportMapFile[] = []) {
+    this.files = []
 
     files.forEach((file) => {
+      this.add(file)
+    })
+  }
+
+  static resolve(importMapFile: ImportMapFile) {
+    const { baseURL, ...importMap } = importMapFile
+    const parsedImportMap = parse(importMap, baseURL)
+
+    return parsedImportMap
+  }
+
+  add(file: ImportMapFile) {
+    this.files.push(file)
+  }
+
+  getContents() {
+    let imports: Record<string, URL | null> = {}
+
+    this.files.forEach((file) => {
       const importMap = ImportMap.resolve(file)
 
       imports = { ...imports, ...importMap.imports }
@@ -34,20 +55,8 @@ class ImportMap {
 
       imports[specifier] = url
     })
-
-    this.imports = imports
-  }
-
-  static resolve(importMapFile: ImportMapFile) {
-    const { baseURL, ...importMap } = importMapFile
-    const parsedImportMap = parse(importMap, baseURL)
-
-    return parsedImportMap
-  }
-
-  getContents() {
     const contents = {
-      imports: this.imports,
+      imports,
     }
 
     return JSON.stringify(contents)

--- a/node/server/server.ts
+++ b/node/server/server.ts
@@ -157,7 +157,7 @@ const serve = async ({
 
   // Creating an ImportMap instance with any import maps supplied by the user,
   // if any.
-  const importMap = new ImportMap(importMaps)
+  const importMap = new ImportMap(importMaps ?? [])
   const flags = ['--allow-all', '--unstable', `--import-map=${importMap.toDataURL()}`, '--no-config']
 
   if (certificatePath) {

--- a/node/utils/error.ts
+++ b/node/utils/error.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isNodeError = (error: any): error is NodeJS.ErrnoException => error instanceof Error

--- a/test/fixtures/with_config/.netlify/edge-functions/config.json
+++ b/test/fixtures/with_config/.netlify/edge-functions/config.json
@@ -1,0 +1,10 @@
+{
+  "functions": [
+    {
+      "function": "func2",
+      "path": "/func2"
+    }
+  ],
+  "import_map": "import_map.json",
+  "version": 1
+}

--- a/test/fixtures/with_config/.netlify/edge-functions/import_map.json
+++ b/test/fixtures/with_config/.netlify/edge-functions/import_map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "alias:helper": "../../../helper.ts"
+  }
+}

--- a/test/fixtures/with_deploy_config/.netlify/edge-functions/config.json
+++ b/test/fixtures/with_deploy_config/.netlify/edge-functions/config.json
@@ -1,0 +1,10 @@
+{
+  "functions": [
+    {
+      "function": "func2",
+      "path": "/func2"
+    }
+  ],
+  "import_map": "import_map.json",
+  "version": 1
+}

--- a/test/fixtures/with_deploy_config/.netlify/edge-functions/func2.ts
+++ b/test/fixtures/with_deploy_config/.netlify/edge-functions/func2.ts
@@ -1,4 +1,4 @@
-import { greet } from 'alias:helper2'
+import { greet } from 'alias:helper'
 
 import { echo } from '../../util.ts'
 

--- a/test/fixtures/with_deploy_config/.netlify/edge-functions/func2.ts
+++ b/test/fixtures/with_deploy_config/.netlify/edge-functions/func2.ts
@@ -1,0 +1,9 @@
+import { greet } from 'alias:helper2'
+
+import { echo } from '../../util.ts'
+
+export default async () => {
+  const greeting = greet(echo('Jane Doe'))
+
+  return new Response(greeting)
+}

--- a/test/fixtures/with_deploy_config/.netlify/edge-functions/import_map.json
+++ b/test/fixtures/with_deploy_config/.netlify/edge-functions/import_map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "alias:helper2": "../../util.ts"
+  }
+}

--- a/test/fixtures/with_deploy_config/.netlify/edge-functions/import_map.json
+++ b/test/fixtures/with_deploy_config/.netlify/edge-functions/import_map.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "alias:helper2": "../../util.ts"
+    "alias:helper": "../../util.ts"
   }
 }

--- a/test/fixtures/with_deploy_config/netlify/edge-functions/func1.ts
+++ b/test/fixtures/with_deploy_config/netlify/edge-functions/func1.ts
@@ -1,0 +1,9 @@
+import { greet } from 'alias:helper1'
+
+import { echo } from '../../util.ts'
+
+export default async () => {
+  const greeting = greet(echo('Jane Doe'))
+
+  return new Response(greeting)
+}

--- a/test/fixtures/with_deploy_config/netlify/edge-functions/func1.ts
+++ b/test/fixtures/with_deploy_config/netlify/edge-functions/func1.ts
@@ -1,9 +1,3 @@
-import { greet } from 'alias:helper1'
-
 import { echo } from '../../util.ts'
 
-export default async () => {
-  const greeting = greet(echo('Jane Doe'))
-
-  return new Response(greeting)
-}
+export default async () => new Response(echo('Jane Doe'))

--- a/test/fixtures/with_deploy_config/util.ts
+++ b/test/fixtures/with_deploy_config/util.ts
@@ -1,0 +1,2 @@
+export const greet = (name: string) => `Hello, ${name}!`
+export const echo = (name: string) => name

--- a/test/fixtures/with_import_maps/functions/config.json
+++ b/test/fixtures/with_import_maps/functions/config.json
@@ -1,0 +1,4 @@
+{
+  "import_map": "import_map.json",
+  "version": 1
+}

--- a/test/fixtures/with_import_maps/functions/import_map.json
+++ b/test/fixtures/with_import_maps/functions/import_map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "alias:helper": "../../helper.ts"
+  }
+}

--- a/test/fixtures/with_layers/functions/config.json
+++ b/test/fixtures/with_layers/functions/config.json
@@ -1,0 +1,4 @@
+{
+  "layers": [{ "name": "test", "flag": "edge-functions-layer-test" }],
+  "version": 1
+}


### PR DESCRIPTION
**Which problem is this pull request solving?**

Framework-generated functions are currently configured using a `manifest.json` file placed in the `.netlify/edge-functions` internal directory (documented [here](https://docs.netlify.com/edge-functions/create-integration/#generate-declarations)). This file is currently [loaded and parsed in Netlify Build](https://github.com/netlify/build/blob/main/packages/build/src/plugins_core/edge_functions/lib/internal_manifest.js) and then its contents are supplied to Edge Bundler via the `declarations`, `layers` and `importMaps` properties.

This PR moves that logic to Edge Bundler, such that the `bundle` entry point receives an optional `configPath` property which indicates the path to this internal configuration file. I've called this `configPath` and used the name `deployConfig` internally to allude to the deploy configuration API initiative, which is basically a part of.

By moving this from Netlify Build to Edge Bundler we'll be consolidating the bundling logic into one place. This will make it easier, for example, to take the `layers` object into account when extracting the function configuration in the ISC process.