### PR TITLE
feat!: remove support for JavaScript bundles

### DIFF
--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -9,11 +9,9 @@ import type { Bundle } from './bundle.js'
 import { FunctionConfig, getFunctionConfig } from './config.js'
 import { Declaration, getDeclarationsFromConfig } from './declaration.js'
 import { load as loadDeployConfig } from './deploy_config.js'
-import { EdgeFunction } from './edge_function.js'
 import { FeatureFlags, getFlags } from './feature_flags.js'
 import { findFunctions } from './finder.js'
 import { bundle as bundleESZIP } from './formats/eszip.js'
-import { bundle as bundleJS } from './formats/javascript.js'
 import { ImportMap } from './import_map.js'
 import { getLogger, LogFunction } from './logger.js'
 import { writeManifest } from './manifest.js'
@@ -29,50 +27,6 @@ interface BundleOptions {
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   systemLogger?: LogFunction
-}
-
-interface BundleFormatOptions {
-  buildID: string
-  debug?: boolean
-  deno: DenoBridge
-  distDirectory: string
-  functions: EdgeFunction[]
-  featureFlags: FeatureFlags
-  importMap: ImportMap
-  basePath: string
-}
-
-const createBundle = ({
-  basePath,
-  buildID,
-  debug,
-  deno,
-  distDirectory,
-  functions,
-  importMap,
-  featureFlags,
-}: BundleFormatOptions) => {
-  if (featureFlags.edge_functions_produce_eszip) {
-    return bundleESZIP({
-      basePath,
-      buildID,
-      debug,
-      deno,
-      distDirectory,
-      featureFlags,
-      functions,
-      importMap,
-    })
-  }
-
-  return bundleJS({
-    buildID,
-    debug,
-    deno,
-    distDirectory,
-    functions,
-    importMap,
-  })
 }
 
 const bundle = async (
@@ -126,7 +80,7 @@ const bundle = async (
   }
 
   const functions = await findFunctions(sourceDirectories)
-  const functionBundle = await createBundle({
+  const functionBundle = await bundleESZIP({
     basePath,
     buildID,
     debug,

--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -154,9 +154,6 @@ test('Ignores function paths from the in-source `config` function if the feature
   const result = await bundle([internalDirectory, userDirectory], tmpDir.path, declarations, {
     basePath: fixturesDir,
     configPath: join(internalDirectory, 'config.json'),
-    featureFlags: {
-      edge_functions_produce_eszip: true,
-    },
   })
   const generatedFiles = await fs.readdir(tmpDir.path)
 
@@ -194,7 +191,6 @@ test('Loads function paths from the in-source `config` function', async () => {
     configPath: join(internalDirectory, 'config.json'),
     featureFlags: {
       edge_functions_config_export: true,
-      edge_functions_produce_eszip: true,
     },
   })
   const generatedFiles = await fs.readdir(tmpDir.path)

--- a/node/feature_flags.ts
+++ b/node/feature_flags.ts
@@ -1,7 +1,6 @@
 const defaultFlags: Record<string, boolean> = {
   edge_functions_cache_deno_dir: false,
   edge_functions_config_export: false,
-  edge_functions_produce_eszip: false,
 }
 
 type FeatureFlag = keyof typeof defaultFlags

--- a/node/server/server.ts
+++ b/node/server/server.ts
@@ -56,7 +56,6 @@ const prepareServer = ({
       functions,
       formatExportTypeError,
       formatImportError,
-      type: 'local',
     })
 
     try {

--- a/test/fixtures/invalid_functions/functions/func1.ts
+++ b/test/fixtures/invalid_functions/functions/func1.ts
@@ -1,1 +1,1 @@
-export default async () => new NotAResponse('Hello')
+export default async () => 

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -57,11 +57,7 @@ const bundleFunction = async (bundlerDir) => {
 
   console.log(`Bundling functions at '${functionsDir}'...`)
 
-  return await bundle([functionsDir], destPath, [{ function: 'func1', path: '/func1' }], {
-    featureFlags: {
-      edge_functions_produce_eszip: true,
-    },
-  })
+  return await bundle([functionsDir], destPath, [{ function: 'func1', path: '/func1' }])
 }
 
 const runAssertions = (bundleOutput) => {


### PR DESCRIPTION
**Which problem is this pull request solving?**

We've been generating ESZIP bundles for all sites for a while now. This PR formally removes support for JavaScript bundles.