### PR TITLE
fix: generate manifest with declaration pattern instead of compiled regex

### DIFF
--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -45,8 +45,8 @@ const generateManifest = ({ bundles = [], declarations = [], functions, layers =
       return
     }
 
-    const pattern = getRegularExpression(declaration)
-    const serializablePattern = pattern.source.replace(/\\\//g, '/')
+    const pattern = getDeclarationPattern(declaration)
+    const serializablePattern = pattern.replace(/\\\//g, '/')
     const route = {
       function: func.name,
       name: declaration.name,
@@ -74,9 +74,9 @@ const generateManifest = ({ bundles = [], declarations = [], functions, layers =
   return manifest
 }
 
-const getRegularExpression = (declaration: Declaration) => {
+const getDeclarationPattern = (declaration: Declaration) => {
   if ('pattern' in declaration) {
-    return new RegExp(declaration.pattern)
+    return declaration.pattern
   }
 
   // We use the global flag so that `globToRegExp` will not wrap the expression
@@ -86,9 +86,7 @@ const getRegularExpression = (declaration: Declaration) => {
   // Wrapping the expression source with `^` and `$`. Also, adding an optional
   // trailing slash, so that a declaration of `path: "/foo"` matches requests
   // for both `/foo` and `/foo/`.
-  const normalizedSource = `^${regularExpression.source}\\/?$`
-
-  return new RegExp(normalizedSource)
+  return `^${regularExpression.source}\\/?$`
 }
 
 interface WriteManifestOptions {


### PR DESCRIPTION
**Which problem is this pull request solving?**

The Next Runtime uses a manifest file generated by Next to create edge function definitions. Part of the those definitions is a route that is defined by a regex pattern in the manifest file.

Next 13 has started using named capture groups in those patterns, which have a slightly different syntax in Golang. In the Next Runtime we convert these patterns to Golang compatible syntax, however the Edge Bundler currently attempts to compile these regex patterns before bundling, causing an error.

**List other issues or pull requests related to this problem**

https://github.com/netlify/next-runtime/pull/1809

**Describe the solution you've chosen**

I couldn't spot any reason why these patterns needed to be compiled into regex objects, so this PR simply keeps the patterns as strings, avoiding the error.

**Describe alternatives you've considered**

An alternative solution would be to perform the Golang syntax transformation in the edge-bundler, later in the bundling stage, instead of doing it in the Next runtime. This could potentially be a more generic solution, but I don't know of the wider impact of this option.