### PR TITLE
fix: add `importMapURL` to manifest validation

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,6 +23,7 @@ module.exports = {
       files: ['node/**/*.test.ts', 'vitest.config.ts'],
       rules: {
         'max-lines-per-function': 'off',
+        'max-nested-callbacks': 'off',
         'max-statements': 'off',
         'no-magic-numbers': 'off',
       },

--- a/node/validation/manifest/__snapshots__/index.test.ts.snap
+++ b/node/validation/manifest/__snapshots__/index.test.ts.snap
@@ -63,7 +63,7 @@ ADDTIONAL PROPERTY must NOT have additional properties
      |       ^^^^^ 😲  foo is not expected to be here!
   28 |     }
   29 |   ],
-  30 |   \\"bundler_version\\": \\"1.6.0\\""
+  30 |   \\"importMapURL\\": \\"file:///root/.netlify/edge-functions-dist/import_map.json\\","
 `;
 
 exports[`layers > should throw on missing flag 1`] = `
@@ -148,29 +148,29 @@ exports[`should show multiple errors 1`] = `
 "Validation of Edge Functions manifest failed
 ADDTIONAL PROPERTY must NOT have additional properties
 
-  28 |   ],
-  29 |   \\"bundler_version\\": \\"1.6.0\\",
-> 30 |   \\"foo\\": \\"bar\\",
+  29 |   \\"importMapURL\\": \\"file:///root/.netlify/edge-functions-dist/import_map.json\\",
+  30 |   \\"bundler_version\\": \\"1.6.0\\",
+> 31 |   \\"foo\\": \\"bar\\",
      |   ^^^^^ 😲  foo is not expected to be here!
-  31 |   \\"baz\\": \\"bar\\"
-  32 | }
+  32 |   \\"baz\\": \\"bar\\"
+  33 | }
 
 ADDTIONAL PROPERTY must NOT have additional properties
 
-  29 |   \\"bundler_version\\": \\"1.6.0\\",
-  30 |   \\"foo\\": \\"bar\\",
-> 31 |   \\"baz\\": \\"bar\\"
+  30 |   \\"bundler_version\\": \\"1.6.0\\",
+  31 |   \\"foo\\": \\"bar\\",
+> 32 |   \\"baz\\": \\"bar\\"
      |   ^^^^^ 😲  baz is not expected to be here!
-  32 | }"
+  33 | }"
 `;
 
 exports[`should throw on additional property on root level 1`] = `
 "Validation of Edge Functions manifest failed
 ADDTIONAL PROPERTY must NOT have additional properties
 
-  28 |   ],
-  29 |   \\"bundler_version\\": \\"1.6.0\\",
-> 30 |   \\"foo\\": \\"bar\\"
+  29 |   \\"importMapURL\\": \\"file:///root/.netlify/edge-functions-dist/import_map.json\\",
+  30 |   \\"bundler_version\\": \\"1.6.0\\",
+> 31 |   \\"foo\\": \\"bar\\"
      |   ^^^^^ 😲  foo is not expected to be here!
-  31 | }"
+  32 | }"
 `;

--- a/node/validation/manifest/index.test.ts
+++ b/node/validation/manifest/index.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-nested-callbacks */
 import { test, expect, describe } from 'vitest'
 
 import { validateManifest, ManifestValidationError } from './index.js'
@@ -33,6 +32,7 @@ const getBaseManifest = (): Record<string, any> => ({
       local: 'local',
     },
   ],
+  importMapURL: 'file:///root/.netlify/edge-functions-dist/import_map.json',
   bundler_version: '1.6.0',
 })
 
@@ -89,6 +89,7 @@ describe('bundle', () => {
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
   })
 })
+
 describe('route', () => {
   test('should throw on additional property', () => {
     const manifest = getBaseManifest()
@@ -143,4 +144,3 @@ describe('layers', () => {
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
   })
 })
-/* eslint-enable max-nested-callbacks */

--- a/node/validation/manifest/schema.ts
+++ b/node/validation/manifest/schema.ts
@@ -55,6 +55,7 @@ const edgeManifestSchema = {
       type: 'array',
       items: layersSchema,
     },
+    importMapURL: { type: 'string' },
     bundler_version: { type: 'string' },
   },
   additionalProperties: false,


### PR DESCRIPTION
**Which problem is this pull request solving?**

Follow up to #235, adding the new `importMapURL` property to the manifest validation logic.