### PR TITLE
fix: correct import_map attribute name in validation

### DIFF
--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -11,6 +11,7 @@ import { useFixture } from '../test/util.js'
 import { BundleError } from './bundle_error.js'
 import { bundle, BundleOptions } from './bundler.js'
 import { isNodeError } from './utils/error.js'
+import { validateManifest } from './validation/manifest/index.ts'
 
 test('Produces an ESZIP bundle', async () => {
   const { basePath, cleanup, distPath } = await useFixture('with_import_maps')
@@ -34,6 +35,7 @@ test('Produces an ESZIP bundle', async () => {
 
   const manifestFile = await fs.readFile(resolve(distPath, 'manifest.json'), 'utf8')
   const manifest = JSON.parse(manifestFile)
+  expect(() => validateManifest(manifest)).not.toThrowError()
   const { bundles, import_map: importMapURL } = manifest
 
   expect(bundles.length).toBe(1)

--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -11,7 +11,7 @@ import { useFixture } from '../test/util.js'
 import { BundleError } from './bundle_error.js'
 import { bundle, BundleOptions } from './bundler.js'
 import { isNodeError } from './utils/error.js'
-import { validateManifest } from './validation/manifest/index.ts'
+import { validateManifest } from './validation/manifest/index.js'
 
 test('Produces an ESZIP bundle', async () => {
   const { basePath, cleanup, distPath } = await useFixture('with_import_maps')

--- a/node/validation/manifest/__snapshots__/index.test.ts.snap
+++ b/node/validation/manifest/__snapshots__/index.test.ts.snap
@@ -59,8 +59,8 @@ TYPE must be string
 
   28 |   ],
   29 |   \\"bundler_version\\": \\"1.6.0\\",
-> 30 |   \\"importMapURL\\": [
-     |                   ^
+> 30 |   \\"import_map\\": [
+     |                 ^
 > 31 |     \\"file:///root/.netlify/edge-functions-dist/import_map.json\\"
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 > 32 |   ]

--- a/node/validation/manifest/index.test.ts
+++ b/node/validation/manifest/index.test.ts
@@ -154,7 +154,7 @@ describe('import map URL', () => {
 
   test('should throw on wrong type', () => {
     const manifest = getBaseManifest()
-    manifest.import_map = ['file:///root/.netlify/edge-functions-dist/import_map.json'] as any
+    manifest.import_map = ['file:///root/.netlify/edge-functions-dist/import_map.json']
 
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
   })

--- a/node/validation/manifest/index.test.ts
+++ b/node/validation/manifest/index.test.ts
@@ -147,14 +147,14 @@ describe('layers', () => {
 describe('import map URL', () => {
   test('should accept string value', () => {
     const manifest = getBaseManifest()
-    manifest.importMapURL = 'file:///root/.netlify/edge-functions-dist/import_map.json'
+    manifest.import_map = 'file:///root/.netlify/edge-functions-dist/import_map.json'
 
     expect(() => validateManifest(manifest)).not.toThrowError()
   })
 
   test('should throw on wrong type', () => {
     const manifest = getBaseManifest()
-    manifest.importMapURL = ['file:///root/.netlify/edge-functions-dist/import_map.json']
+    manifest.import_map = ['file:///root/.netlify/edge-functions-dist/import_map.json'] as any
 
     expect(() => validateManifest(manifest)).toThrowErrorMatchingSnapshot()
   })

--- a/node/validation/manifest/schema.ts
+++ b/node/validation/manifest/schema.ts
@@ -55,7 +55,7 @@ const edgeManifestSchema = {
       type: 'array',
       items: layersSchema,
     },
-    importMapURL: { type: 'string' },
+    import_map: { type: 'string' },
     bundler_version: { type: 'string' },
   },
   additionalProperties: false,


### PR DESCRIPTION
Follow up to https://github.com/netlify/edge-bundler/pull/239, where the schema said `importMapURL` as the key name instead of `import_map` which is correct.