### PR TITLE
feat: use `netlify:import-map` specifier

### DIFF
--- a/deno/bundle.ts
+++ b/deno/bundle.ts
@@ -1,6 +1,6 @@
 import { writeStage2 } from './lib/stage2.ts'
 
 const [payload] = Deno.args
-const { basePath, destPath, externals, functions, importMapURL } = JSON.parse(payload)
+const { basePath, destPath, externals, functions, importMapData } = JSON.parse(payload)
 
-await writeStage2({ basePath, destPath, externals, functions, importMapURL })
+await writeStage2({ basePath, destPath, externals, functions, importMapData })

--- a/deno/lib/stage2.ts
+++ b/deno/lib/stage2.ts
@@ -3,7 +3,7 @@ import { build, LoadResponse } from 'https://deno.land/x/eszip@v0.28.0/mod.ts'
 import * as path from 'https://deno.land/std@0.127.0/path/mod.ts'
 
 import type { InputFunction, WriteStage2Options } from '../../shared/stage2.ts'
-import { virtualRoot } from '../../shared/consts.ts'
+import { importMapSpecifier, virtualRoot } from '../../shared/consts.ts'
 import { PUBLIC_SPECIFIER, STAGE2_SPECIFIER } from './consts.ts'
 import { inlineModule, loadFromVirtualRoot, loadWithRetry } from './common.ts'
 
@@ -63,12 +63,16 @@ const getVirtualPath = (basePath: string, filePath: string) => {
   return url
 }
 
-const stage2Loader = (basePath: string, functions: InputFunction[], externals: Set<string>) => {
+const stage2Loader = (basePath: string, functions: InputFunction[], externals: Set<string>, importMapData?: string) => {
   return async (specifier: string): Promise<LoadResponse | undefined> => {
     if (specifier === STAGE2_SPECIFIER) {
       const stage2Entry = getStage2Entry(basePath, functions)
 
       return inlineModule(specifier, stage2Entry)
+    }
+
+    if (specifier === importMapSpecifier && importMapData !== undefined) {
+      return inlineModule(specifier, importMapData)
     }
 
     if (specifier === PUBLIC_SPECIFIER || externals.has(specifier)) {
@@ -86,9 +90,9 @@ const stage2Loader = (basePath: string, functions: InputFunction[], externals: S
   }
 }
 
-const writeStage2 = async ({ basePath, destPath, externals, functions, importMapURL }: WriteStage2Options) => {
-  const loader = stage2Loader(basePath, functions, new Set(externals))
-  const bytes = await build([STAGE2_SPECIFIER], loader, importMapURL)
+const writeStage2 = async ({ basePath, destPath, externals, functions, importMapData }: WriteStage2Options) => {
+  const loader = stage2Loader(basePath, functions, new Set(externals), importMapData)
+  const bytes = await build([STAGE2_SPECIFIER], loader, importMapSpecifier)
   const directory = path.dirname(destPath)
 
   await Deno.mkdir(directory, { recursive: true })

--- a/deno/lib/stage2.ts
+++ b/deno/lib/stage2.ts
@@ -91,8 +91,9 @@ const stage2Loader = (basePath: string, functions: InputFunction[], externals: S
 }
 
 const writeStage2 = async ({ basePath, destPath, externals, functions, importMapData }: WriteStage2Options) => {
+  const importMapURL = importMapData ? importMapSpecifier : undefined
   const loader = stage2Loader(basePath, functions, new Set(externals), importMapData)
-  const bytes = await build([STAGE2_SPECIFIER], loader, importMapSpecifier)
+  const bytes = await build([STAGE2_SPECIFIER], loader, importMapURL)
   const directory = path.dirname(destPath)
 
   await Deno.mkdir(directory, { recursive: true })

--- a/node/bundle.ts
+++ b/node/bundle.ts
@@ -7,5 +7,4 @@ export interface Bundle {
   extension: string
   format: BundleFormat
   hash: string
-  importMapURL?: string
 }

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -4,6 +4,8 @@ import { join } from 'path'
 import commonPathPrefix from 'common-path-prefix'
 import { v4 as uuidv4 } from 'uuid'
 
+import { importMapSpecifier } from '../shared/consts.js'
+
 import { DenoBridge, DenoOptions, OnAfterDownloadHook, OnBeforeDownloadHook } from './bridge.js'
 import type { Bundle } from './bundle.js'
 import { FunctionConfig, getFunctionConfig } from './config.js'
@@ -126,7 +128,7 @@ const bundle = async (
     declarations,
     distDirectory,
     functions,
-    importMapURL: functionBundle.importMapURL,
+    importMap: importMapSpecifier,
     layers: deployConfig.layers,
   })
 

--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -158,9 +158,7 @@ test('Ignores function paths from the in-source `config` function if the feature
   const generatedFiles = await fs.readdir(distPath)
 
   expect(result.functions.length).toBe(6)
-
-  // ESZIP, manifest and import map.
-  expect(generatedFiles.length).toBe(3)
+  expect(generatedFiles.length).toBe(2)
 
   const manifestFile = await fs.readFile(resolve(distPath, 'manifest.json'), 'utf8')
   const manifest = JSON.parse(manifestFile)
@@ -198,9 +196,7 @@ test('Loads function paths from the in-source `config` function', async () => {
   const generatedFiles = await fs.readdir(distPath)
 
   expect(result.functions.length).toBe(6)
-
-  // ESZIP, manifest and import map.
-  expect(generatedFiles.length).toBe(3)
+  expect(generatedFiles.length).toBe(2)
 
   const manifestFile = await fs.readFile(resolve(distPath, 'manifest.json'), 'utf8')
   const manifest = JSON.parse(manifestFile)

--- a/node/import_map.test.ts
+++ b/node/import_map.test.ts
@@ -22,14 +22,14 @@ test('Handles import maps with full URLs without specifying a base URL', () => {
   }
 
   const map = new ImportMap([inputFile1, inputFile2])
-  const { imports } = JSON.parse(map.getContents())
+  const { imports } = map.getContents()
 
   expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
   expect(imports['alias:jamstack']).toBe('https://jamstack.org/')
   expect(imports['alias:pets']).toBe('https://petsofnetlify.com/')
 })
 
-test('Resolves relative paths to absolute paths if a root path is not provided', () => {
+test('Resolves relative paths to absolute paths if a base path is not provided', () => {
   const basePath = join(cwd(), 'my-cool-site', 'import-map.json')
   const inputFile1 = {
     baseURL: pathToFileURL(basePath),
@@ -39,14 +39,14 @@ test('Resolves relative paths to absolute paths if a root path is not provided',
   }
 
   const map = new ImportMap([inputFile1])
-  const { imports } = JSON.parse(map.getContents())
+  const { imports } = map.getContents()
   const expectedPath = join(cwd(), 'my-cool-site', 'heart', 'pets')
 
   expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
   expect(imports['alias:pets']).toBe(`${pathToFileURL(expectedPath).toString()}/`)
 })
 
-test('Transforms relative paths so that they use the root path as a base', () => {
+test('Transforms relative paths so that they become relative to the base path', () => {
   const basePath = join(cwd(), 'my-cool-site', 'import-map.json')
   const inputFile1 = {
     baseURL: pathToFileURL(basePath),
@@ -55,9 +55,33 @@ test('Transforms relative paths so that they use the root path as a base', () =>
     },
   }
 
-  const map = new ImportMap([inputFile1])
-  const { imports } = JSON.parse(map.getContents(cwd()))
+  // Without a prefix.
+  const map1 = new ImportMap([inputFile1])
+  const { imports: imports1 } = map1.getContents(cwd())
 
-  expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
-  expect(imports['alias:pets']).toBe('./my-cool-site/heart/pets')
+  expect(imports1['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
+  expect(imports1['alias:pets']).toBe('file:///my-cool-site/heart/pets/')
+
+  // With a prefix.
+  const map2 = new ImportMap([inputFile1])
+  const { imports: imports2 } = map2.getContents(cwd(), 'file:///root/')
+
+  expect(imports2['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
+  expect(imports2['alias:pets']).toBe('file:///root/my-cool-site/heart/pets/')
+})
+
+test('Throws when an import map uses a relative path to reference a file outside of the base path', () => {
+  const basePath = join(cwd(), 'my-cool-site')
+  const inputFile1 = {
+    baseURL: pathToFileURL(join(basePath, 'import_map.json')),
+    imports: {
+      'alias:file': '../file.js',
+    },
+  }
+
+  const map = new ImportMap([inputFile1])
+
+  expect(() => map.getContents(basePath)).toThrowError(
+    `Import map cannot reference '${join(cwd(), 'file.js')}' as it's outside of the base directory '${basePath}'`,
+  )
 })

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -15,7 +15,7 @@ interface GenerateManifestOptions {
   bundles?: Bundle[]
   declarations?: Declaration[]
   functions: EdgeFunction[]
-  importMapURL?: string
+  importMap?: string
   layers?: Layer[]
 }
 
@@ -40,7 +40,7 @@ const generateManifest = ({
   bundles = [],
   declarations = [],
   functions,
-  importMapURL,
+  importMap,
   layers = [],
 }: GenerateManifestOptions) => {
   const preCacheRoutes: Route[] = []
@@ -77,7 +77,7 @@ const generateManifest = ({
     post_cache_routes: postCacheRoutes.filter(nonNullable),
     bundler_version: getPackageVersion(),
     layers,
-    import_map: importMapURL,
+    import_map: importMap,
   }
 
   return manifest
@@ -105,7 +105,7 @@ interface WriteManifestOptions {
   declarations: Declaration[]
   distDirectory: string
   functions: EdgeFunction[]
-  importMapURL?: string
+  importMap?: string
   layers?: Layer[]
 }
 
@@ -114,10 +114,10 @@ const writeManifest = async ({
   declarations = [],
   distDirectory,
   functions,
-  importMapURL,
+  importMap,
   layers,
 }: WriteManifestOptions) => {
-  const manifest = generateManifest({ bundles, declarations, functions, importMapURL, layers })
+  const manifest = generateManifest({ bundles, declarations, functions, importMap, layers })
   const manifestPath = join(distDirectory, 'manifest.json')
 
   await fs.writeFile(manifestPath, JSON.stringify(manifest))

--- a/node/server/server.ts
+++ b/node/server/server.ts
@@ -156,7 +156,7 @@ const serve = async ({
 
   // Creating an ImportMap instance with any import maps supplied by the user,
   // if any.
-  const importMap = new ImportMap(importMaps ?? [])
+  const importMap = new ImportMap(importMaps)
   const flags = ['--allow-all', '--unstable', `--import-map=${importMap.toDataURL()}`, '--no-config']
 
   if (certificatePath) {

--- a/shared/consts.ts
+++ b/shared/consts.ts
@@ -1,1 +1,2 @@
+export const importMapSpecifier = 'netlify:import-map'
 export const virtualRoot = 'file:///root/'

--- a/shared/stage2.ts
+++ b/shared/stage2.ts
@@ -8,5 +8,5 @@ export interface WriteStage2Options {
   destPath: string
   externals: string[]
   functions: InputFunction[]
-  importMapURL?: string
+  importMapData?: string
 }

--- a/test/fixtures/with_import_maps/functions/func1.ts
+++ b/test/fixtures/with_import_maps/functions/func1.ts
@@ -1,9 +1,9 @@
 import { greet } from 'alias:helper'
-
+import { yell } from 'util/helper.ts'
 import { echo } from '../helper.ts'
 
 export default async () => {
-  const greeting = greet(echo('Jane Doe'))
+  const greeting = yell(greet(echo('Jane Doe')))
 
   return new Response(greeting)
 }

--- a/test/fixtures/with_import_maps/functions/import_map.json
+++ b/test/fixtures/with_import_maps/functions/import_map.json
@@ -1,5 +1,6 @@
 {
   "imports": {
-    "alias:helper": "../helper.ts"
+    "alias:helper": "../helper.ts",
+    "util/": "../"
   }
 }

--- a/test/fixtures/with_import_maps/helper.ts
+++ b/test/fixtures/with_import_maps/helper.ts
@@ -1,2 +1,3 @@
 export const greet = (name: string) => `Hello, ${name}!`
 export const echo = (name: string) => name
+export const yell = (message: string) => message.toUpperCase()

--- a/test/util.ts
+++ b/test/util.ts
@@ -2,13 +2,13 @@ import { promises as fs } from 'fs'
 import { join, resolve } from 'path'
 import { fileURLToPath } from 'url'
 
-import cpy from 'cpy'
 import tmp from 'tmp-promise'
 
 import { getLogger } from '../node/logger.js'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const testLogger = getLogger(() => {})
+const testLogger = getLogger(() => {
+  // no-op
+})
 
 const url = new URL(import.meta.url)
 const dirname = fileURLToPath(url)
@@ -18,13 +18,10 @@ const useFixture = async (fixtureName: string) => {
   const tmpDir = await tmp.dir()
   const cleanup = () => fs.rmdir(tmpDir.path, { recursive: true })
   const fixtureDir = resolve(fixturesDir, fixtureName)
-
-  await cpy(`${fixtureDir}/**`, tmpDir.path)
-
   const distPath = join(tmpDir.path, '.netlify', 'edge-functions-dist')
 
   return {
-    basePath: tmpDir.path,
+    basePath: fixtureDir,
     cleanup,
     distPath,
   }


### PR DESCRIPTION
**Which problem is this pull request solving?**

In #235 we started writing the import map URL to the manifest. We were writing an actual import map file to disk, to the dist directory, and then building a virtual path relative to the repository root.

For example, the following project would yield a path of `file:///root/.netlify/edge-functions-dist/import_map.json` for the import map.

```
.netlify/
  edge-functions-dist/
    import_map.json
other-file
```

While this works great for projects with this structure, it doesn't work that well when the dist directory is not a child directory of the repository root, because we won't be able to encode a relative path into the file URL (e.g. something like `file:///root/../../import_map.json` is not valid).

What happens now in these situations is that we end up using an absolute path rather than a relative one, which has the problem of being a path that is specific to the machine that builds it — we can end up with things like `file:///Users/johndoe/import_map` in the ESZIP, and while that technically works, it's not something we want to do.

This PR changes things a bit so that we don't compute a relative path from the import map file to the repository root, and in fact we stop writing an import map file at all. We give the ESZIP loader a static specifier for the import map (`netlify:import-map`) and then map it to the contents of the import map.

The imports themselves are rewritten so that any relative paths have the repository root as the base, using the `file:///root/` prefix. These relative paths we know we can always generate, because any file referenced by the import map should always be a child of the repository root (otherwise it can't be deployed).