### PR TITLE
fix: do not transform paths when writing import map to disk

### DIFF
--- a/node/import_map.ts
+++ b/node/import_map.ts
@@ -115,7 +115,7 @@ class ImportMap {
 
     await fs.mkdir(distDirectory, { recursive: true })
 
-    const contents = this.getContents(distDirectory)
+    const contents = this.getContents()
 
     await fs.writeFile(path, JSON.stringify(contents))
   }


### PR DESCRIPTION
**Which problem is this pull request solving?**

We're writing import map files to disk so that integrations like the VSCode plugin can pick them up. In https://github.com/netlify/edge-bundler/pull/235 we started resolving these paths relative (by passing an argument to `getContents()`), but that's a bad idea because we're not surfacing the repository root, and so we're resolving them with the wrong base.

This PR reverts that, such that import maps written to a file get absolute paths.