### PR TITLE
feat!: add support for user-defined import maps

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,7 +4,7 @@ const { overrides } = require('@netlify/eslint-config-node')
 
 module.exports = {
   extends: '@netlify/eslint-config-node',
-  ignorePatterns: ['deno/**/*.ts', 'test/deno/**/*.ts'],
+  ignorePatterns: ['deno/**/*.ts', 'test/deno/**/*.ts', 'test/fixtures/**/*.ts'],
   parserOptions: {
     sourceType: 'module',
   },

--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -22,14 +22,15 @@ test('Produces an ESZIP bundle', async () => {
       path: '/func1',
     },
   ]
-  const sourceDirectory = join(basePath, 'functions')
-  const result = await bundle([sourceDirectory], distPath, declarations, {
+  const userDirectory = join(basePath, 'user-functions')
+  const internalDirectory = join(basePath, 'functions')
+  const result = await bundle([userDirectory, internalDirectory], distPath, declarations, {
     basePath,
-    configPath: join(sourceDirectory, 'config.json'),
+    configPath: join(internalDirectory, 'config.json'),
   })
   const generatedFiles = await fs.readdir(distPath)
 
-  expect(result.functions.length).toBe(1)
+  expect(result.functions.length).toBe(2)
   expect(generatedFiles.length).toBe(2)
 
   const manifestFile = await fs.readFile(resolve(distPath, 'manifest.json'), 'utf8')

--- a/node/deno_config.test.ts
+++ b/node/deno_config.test.ts
@@ -40,6 +40,57 @@ test('Throws a type error if the `importMap` contains anything other than a stri
   await cleanup()
 })
 
+test('Excludes unsupported properties', async () => {
+  const { cleanup, path } = await tmp.dir({ unsafeCleanup: true })
+  const configPath = join(path, 'deno.json')
+  const data = JSON.stringify({
+    compilerOptions: {
+      allowJs: true,
+      lib: ['deno.window'],
+      strict: true,
+    },
+    importMap: 'import_map.json',
+    lint: {
+      files: {
+        include: ['src/'],
+        exclude: ['src/testdata/'],
+      },
+      rules: {
+        tags: ['recommended'],
+        include: ['ban-untagged-todo'],
+        exclude: ['no-unused-vars'],
+      },
+    },
+    fmt: {
+      files: {
+        include: ['src/'],
+        exclude: ['src/testdata/'],
+      },
+      options: {
+        useTabs: true,
+        lineWidth: 80,
+        indentWidth: 4,
+        singleQuote: true,
+        proseWrap: 'preserve',
+      },
+    },
+    test: {
+      files: {
+        include: ['src/'],
+        exclude: ['src/testdata/'],
+      },
+    },
+  })
+
+  await fs.writeFile(configPath, data)
+
+  const config = await getConfig(path)
+
+  expect(Object.keys(config ?? {})).toEqual(['importMap'])
+
+  await cleanup()
+})
+
 test('Resolves `importMap` into an absolute path', async () => {
   const { cleanup, path } = await tmp.dir({ unsafeCleanup: true })
   const configPath = join(path, 'deno.json')

--- a/node/deno_config.test.ts
+++ b/node/deno_config.test.ts
@@ -7,7 +7,7 @@ import { expect, test } from 'vitest'
 import { getConfig } from './deno_config.js'
 
 test('Returns `undefined` if no config file is found', async () => {
-  const { cleanup, path } = await tmp.dir()
+  const { cleanup, path } = await tmp.dir({ unsafeCleanup: true })
   const config = await getConfig(path)
 
   expect(config).toBeUndefined()
@@ -16,7 +16,7 @@ test('Returns `undefined` if no config file is found', async () => {
 })
 
 test('Returns an empty object if the config file cannot be parsed', async () => {
-  const { path } = await tmp.dir()
+  const { cleanup, path } = await tmp.dir({ unsafeCleanup: true })
   const configPath = join(path, 'deno.json')
 
   await fs.writeFile(configPath, '{')
@@ -25,11 +25,11 @@ test('Returns an empty object if the config file cannot be parsed', async () => 
 
   expect(config).toEqual({})
 
-  await fs.rm(path, { recursive: true })
+  await cleanup()
 })
 
 test('Resolves `importMap` into an absolute path', async () => {
-  const { path } = await tmp.dir()
+  const { cleanup, path } = await tmp.dir({ unsafeCleanup: true })
   const configPath = join(path, 'deno.json')
   const data = JSON.stringify({ importMap: 'import_map.json' })
 
@@ -39,11 +39,11 @@ test('Resolves `importMap` into an absolute path', async () => {
 
   expect(config).toEqual({ importMap: join(path, 'import_map.json') })
 
-  await fs.rm(path, { recursive: true })
+  await cleanup()
 })
 
 test('Supports JSONC', async () => {
-  const { path } = await tmp.dir()
+  const { cleanup, path } = await tmp.dir({ unsafeCleanup: true })
   const configPath = join(path, 'deno.jsonc')
   const data = JSON.stringify({ importMap: 'import_map.json' })
 
@@ -53,5 +53,5 @@ test('Supports JSONC', async () => {
 
   expect(config).toEqual({ importMap: join(path, 'import_map.json') })
 
-  await fs.rm(path, { recursive: true })
+  await cleanup()
 })

--- a/node/deno_config.test.ts
+++ b/node/deno_config.test.ts
@@ -28,6 +28,18 @@ test('Returns an empty object if the config file cannot be parsed', async () => 
   await cleanup()
 })
 
+test('Throws a type error if the `importMap` contains anything other than a string', async () => {
+  const { cleanup, path } = await tmp.dir({ unsafeCleanup: true })
+  const configPath = join(path, 'deno.json')
+  const data = JSON.stringify({ importMap: { imports: { foo: './bar/' } } })
+
+  await fs.writeFile(configPath, data)
+
+  await expect(getConfig(path)).rejects.toThrowError(TypeError)
+
+  await cleanup()
+})
+
 test('Resolves `importMap` into an absolute path', async () => {
   const { cleanup, path } = await tmp.dir({ unsafeCleanup: true })
   const configPath = join(path, 'deno.json')

--- a/node/deno_config.test.ts
+++ b/node/deno_config.test.ts
@@ -1,0 +1,57 @@
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+import tmp from 'tmp-promise'
+import { expect, test } from 'vitest'
+
+import { getConfig } from './deno_config.js'
+
+test('Returns `undefined` if no config file is found', async () => {
+  const { cleanup, path } = await tmp.dir()
+  const config = await getConfig(path)
+
+  expect(config).toBeUndefined()
+
+  await cleanup()
+})
+
+test('Returns an empty object if the config file cannot be parsed', async () => {
+  const { path } = await tmp.dir()
+  const configPath = join(path, 'deno.json')
+
+  await fs.writeFile(configPath, '{')
+
+  const config = await getConfig(path)
+
+  expect(config).toEqual({})
+
+  await fs.rm(path, { recursive: true })
+})
+
+test('Resolves `importMap` into an absolute path', async () => {
+  const { path } = await tmp.dir()
+  const configPath = join(path, 'deno.json')
+  const data = JSON.stringify({ importMap: 'import_map.json' })
+
+  await fs.writeFile(configPath, data)
+
+  const config = await getConfig(path)
+
+  expect(config).toEqual({ importMap: join(path, 'import_map.json') })
+
+  await fs.rm(path, { recursive: true })
+})
+
+test('Supports JSONC', async () => {
+  const { path } = await tmp.dir()
+  const configPath = join(path, 'deno.jsonc')
+  const data = JSON.stringify({ importMap: 'import_map.json' })
+
+  await fs.writeFile(configPath, `// This is a comment\n${data}`)
+
+  const config = await getConfig(path)
+
+  expect(config).toEqual({ importMap: join(path, 'import_map.json') })
+
+  await fs.rm(path, { recursive: true })
+})

--- a/node/deno_config.ts
+++ b/node/deno_config.ts
@@ -1,0 +1,52 @@
+import { promises as fs } from 'fs'
+import { join, resolve } from 'path'
+
+import { parse as parseJSONC } from 'jsonc-parser'
+
+import { isNodeError } from './utils/error.js'
+
+interface DenoConfigFile {
+  importMap?: string
+}
+
+const filenames = ['deno.json', 'deno.jsonc']
+
+export const getConfig = async (basePath?: string) => {
+  if (basePath === undefined) {
+    return
+  }
+
+  for (const filename of filenames) {
+    const candidatePath = join(basePath, filename)
+    const config = await getConfigFromFile(candidatePath)
+
+    if (config !== undefined) {
+      return normalizeConfig(config, basePath)
+    }
+  }
+}
+
+const getConfigFromFile = async (filePath: string) => {
+  try {
+    const data = await fs.readFile(filePath, 'utf8')
+    const config = parseJSONC(data) as DenoConfigFile
+
+    return config
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return
+    }
+
+    return {}
+  }
+}
+
+const normalizeConfig = (config: DenoConfigFile, basePath: string) => {
+  const newConfig = { ...config }
+
+  if (newConfig.importMap) {
+    newConfig.importMap = resolve(basePath, newConfig.importMap)
+  }
+
+  return newConfig
+}

--- a/node/deno_config.ts
+++ b/node/deno_config.ts
@@ -41,12 +41,16 @@ const getConfigFromFile = async (filePath: string) => {
   }
 }
 
-const normalizeConfig = (config: DenoConfigFile, basePath: string) => {
-  const newConfig = { ...config }
+const normalizeConfig = (rawConfig: DenoConfigFile, basePath: string) => {
+  const config: DenoConfigFile = {}
 
-  if (newConfig.importMap) {
-    newConfig.importMap = resolve(basePath, newConfig.importMap)
+  if (rawConfig.importMap) {
+    if (typeof rawConfig.importMap !== 'string') {
+      throw new TypeError(`'importMap' property in Deno config must be a string`)
+    }
+
+    config.importMap = resolve(basePath, rawConfig.importMap)
   }
 
-  return newConfig
+  return config
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "find-up": "^6.3.0",
         "get-port": "^6.1.2",
         "glob-to-regexp": "^0.4.1",
+        "jsonc-parser": "^3.2.0",
         "node-fetch": "^3.1.1",
         "node-stream-zip": "^1.15.0",
         "p-retry": "^5.1.1",
@@ -6315,6 +6316,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -13859,6 +13865,11 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
+    },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "jsonfile": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "find-up": "^6.3.0",
     "get-port": "^6.1.2",
     "glob-to-regexp": "^0.4.1",
+    "jsonc-parser": "^3.2.0",
     "node-fetch": "^3.1.1",
     "node-stream-zip": "^1.15.0",
     "p-retry": "^5.1.1",

--- a/test/fixtures/serve_test/.netlify/edge-functions/greet.ts
+++ b/test/fixtures/serve_test/.netlify/edge-functions/greet.ts
@@ -1,0 +1,3 @@
+import { yell } from 'internal-helper'
+
+export default async () => new Response(yell('Hello!'))

--- a/test/fixtures/serve_test/.netlify/edge-functions/import_map.json
+++ b/test/fixtures/serve_test/.netlify/edge-functions/import_map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "internal-helper": "../../helper.ts"
+  }
+}

--- a/test/fixtures/serve_test/deno.json
+++ b/test/fixtures/serve_test/deno.json
@@ -1,0 +1,3 @@
+{
+  "importMap": "import_map.json"
+}

--- a/test/fixtures/serve_test/helper.ts
+++ b/test/fixtures/serve_test/helper.ts
@@ -1,0 +1,1 @@
+export const yell = (message: string) => message.toUpperCase()

--- a/test/fixtures/serve_test/import_map.json
+++ b/test/fixtures/serve_test/import_map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "helper": "./helper.ts"
+  }
+}

--- a/test/fixtures/serve_test/netlify/edge-functions/echo_env.ts
+++ b/test/fixtures/serve_test/netlify/edge-functions/echo_env.ts
@@ -1,6 +1,8 @@
 import { Config } from 'https://edge.netlify.com'
 
-export default async () => new Response(JSON.stringify(Deno.env.toObject()))
+import { yell } from 'helper'
+
+export default async () => new Response(yell(Deno.env.get('very_secret_secret')))
 
 export const config: Config = () => ({
   path: '/my-function',

--- a/test/fixtures/serve_test/netlify/edge-functions/echo_env.ts
+++ b/test/fixtures/serve_test/netlify/edge-functions/echo_env.ts
@@ -2,7 +2,7 @@ import { Config } from 'https://edge.netlify.com'
 
 import { yell } from 'helper'
 
-export default async () => new Response(yell(Deno.env.get('very_secret_secret')))
+export default () => new Response(yell(Deno.env.get('very_secret_secret') ?? ''))
 
 export const config: Config = () => ({
   path: '/my-function',

--- a/test/fixtures/with_import_maps/deno.json
+++ b/test/fixtures/with_import_maps/deno.json
@@ -1,0 +1,3 @@
+{
+  "importMap": "import_map.json"
+}

--- a/test/fixtures/with_import_maps/import_map.json
+++ b/test/fixtures/with_import_maps/import_map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "helper": "./helper.ts"
+  }
+}

--- a/test/fixtures/with_import_maps/user-functions/func2.ts
+++ b/test/fixtures/with_import_maps/user-functions/func2.ts
@@ -1,0 +1,7 @@
+import { echo } from 'helper'
+
+export default async () => {
+  const greeting = echo('Jane Doe')
+
+  return new Response(greeting)
+}


### PR DESCRIPTION
**Which problem is this pull request solving?**

Currently, the only way to use import maps with edge functions is by placing an import map file inside the internal edge functions directory, which is meant for integrations.

This PR adds support for user-defined import maps by looking for a [Deno configuration file](https://deno.land/manual@v1.28.3/getting_started/configuration_file) at `/deno.json` or `/deno.jsonc`. When this file is found and it contains an `importMap` property, we load that import map into the existing flow.

**List other issues or pull requests related to this problem**

Closes https://github.com/netlify/pod-compute/issues/206