### PR TITLE
feat: read Deno config behind feature flag

### DIFF
--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -27,6 +27,9 @@ test('Produces an ESZIP bundle', async () => {
   const result = await bundle([userDirectory, internalDirectory], distPath, declarations, {
     basePath,
     configPath: join(internalDirectory, 'config.json'),
+    featureFlags: {
+      edge_functions_read_deno_config: true,
+    },
   })
   const generatedFiles = await fs.readdir(distPath)
 

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -85,15 +85,17 @@ const bundle = async (
     importMap.add(deployConfig.importMap)
   }
 
-  // Look for a Deno config file and read it if one exists.
-  const denoConfig = await getDenoConfig(basePath)
+  if (featureFlags.edge_functions_read_deno_config) {
+    // Look for a Deno config file and read it if one exists.
+    const denoConfig = await getDenoConfig(basePath)
 
-  // If the Deno config file defines an import map, read the file and add the
-  // imports to the global import map.
-  if (denoConfig?.importMap) {
-    const importMapFile = await readImportMapFile(denoConfig.importMap)
+    // If the Deno config file defines an import map, read the file and add the
+    // imports to the global import map.
+    if (denoConfig?.importMap) {
+      const importMapFile = await readImportMapFile(denoConfig.importMap)
 
-    importMap.add(importMapFile)
+      importMap.add(importMapFile)
+    }
   }
 
   const functions = await findFunctions(sourceDirectories)

--- a/node/feature_flags.ts
+++ b/node/feature_flags.ts
@@ -1,6 +1,7 @@
 const defaultFlags: Record<string, boolean> = {
   edge_functions_cache_deno_dir: false,
   edge_functions_config_export: false,
+  edge_functions_read_deno_config: false,
 }
 
 type FeatureFlag = keyof typeof defaultFlags


### PR DESCRIPTION
**Which problem is this pull request solving?**

Follow-up to #256. Adds a feature flag around the logic that reads the Deno config.