### PR TITLE
fix: read other import map paths when one doesn't exist

### DIFF
--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs'
 import { join, resolve } from 'path'
 import process from 'process'
+import { pathToFileURL } from 'url'
 
 import { deleteAsync } from 'del'
 import tmp from 'tmp-promise'
@@ -352,11 +353,11 @@ test("Ignores entries in `importMapPaths` that don't point to an existing import
   const importMap = await tmp.file()
   const importMapContents = {
     imports: {
-      helper: join(basePath, 'helper.ts'),
+      helper: pathToFileURL(join(basePath, 'helper.ts')).toString(),
     },
     scopes: {
-      [join(sourceDirectory, 'func3')]: {
-        helper: join(basePath, 'helper2.ts'),
+      [pathToFileURL(join(sourceDirectory, 'func3')).toString()]: {
+        helper: pathToFileURL(join(basePath, 'helper2.ts')).toString(),
       },
     },
   }

--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -346,25 +346,45 @@ test('Loads declarations and import maps from the deploy configuration', async (
 test("Ignores entries in `importMapPaths` that don't point to an existing import map file", async () => {
   const systemLogger = vi.fn()
   const { basePath, cleanup, distPath } = await useFixture('with_import_maps')
-  const sourceDirectory = join(basePath, 'functions')
-  const importMapPath = join(distPath, 'some-file-that-does-not-exist.json')
-  const declarations = [
-    {
-      function: 'func1',
-      path: '/func1',
+  const sourceDirectory = join(basePath, 'user-functions')
+
+  // Creating import map file
+  const importMap = await tmp.file()
+  const importMapContents = {
+    imports: {
+      helper: join(basePath, 'helper.ts'),
     },
-  ]
-  const result = await bundle([sourceDirectory], distPath, declarations, {
-    basePath,
-    configPath: join(sourceDirectory, 'config.json'),
-    importMapPaths: [importMapPath],
-    systemLogger,
-  })
+    scopes: {
+      [join(sourceDirectory, 'func3')]: {
+        helper: join(basePath, 'helper2.ts'),
+      },
+    },
+  }
+
+  await fs.writeFile(importMap.path, JSON.stringify(importMapContents))
+
+  const nonExistingImportMapPath = join(distPath, 'some-file-that-does-not-exist.json')
+  const result = await bundle(
+    [sourceDirectory],
+    distPath,
+    [
+      {
+        function: 'func1',
+        path: '/func1',
+      },
+    ],
+    {
+      basePath,
+      importMapPaths: [nonExistingImportMapPath, importMap.path],
+      systemLogger,
+    },
+  )
   const generatedFiles = await fs.readdir(distPath)
 
-  expect(result.functions.length).toBe(1)
+  expect(result.functions.length).toBe(2)
   expect(generatedFiles.length).toBe(2)
-  expect(systemLogger).toHaveBeenCalledWith(`Did not find an import map file at '${importMapPath}'.`)
+  expect(systemLogger).toHaveBeenCalledWith(`Did not find an import map file at '${nonExistingImportMapPath}'.`)
 
   await cleanup()
+  await importMap.cleanup()
 })

--- a/node/import_map.ts
+++ b/node/import_map.ts
@@ -124,7 +124,7 @@ class ImportMap {
   async addFiles(paths: (string | undefined)[], logger: Logger) {
     for (const path of paths) {
       if (path === undefined) {
-        return
+        continue
       }
 
       await this.addFile(path, logger)

--- a/test/util.ts
+++ b/test/util.ts
@@ -17,14 +17,13 @@ const dirname = fileURLToPath(url)
 const fixturesDir = resolve(dirname, '..', 'fixtures')
 
 const useFixture = async (fixtureName: string) => {
-  const tmpDir = await tmp.dir()
-  const cleanup = () => fs.rmdir(tmpDir.path, { recursive: true })
+  const tmpDir = await tmp.dir({ unsafeCleanup: true })
   const fixtureDir = resolve(fixturesDir, fixtureName)
   const distPath = join(tmpDir.path, '.netlify', 'edge-functions-dist')
 
   return {
     basePath: fixtureDir,
-    cleanup,
+    cleanup: tmpDir.cleanup,
     distPath,
   }
 }


### PR DESCRIPTION
**Which problem is this pull request solving?**

Fixes a bug in #265 that prevents additional import map paths from being read when one points to a non-existing file.