### PR TITLE
fix: print nice npm error message for npm: specifier as well

### DIFF
--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -131,7 +131,31 @@ test('Prints a nice error message when user tries importing NPM module', async (
   } catch (error) {
     expect(error).toBeInstanceOf(BundleError)
     expect((error as BundleError).message).toEqual(
-      `It seems like you're trying to import an npm module. This is only supported in Deno via CDNs like esm.sh. Have you tried 'import mod from "https://esm.sh/p-retry"'?`,
+      `It seems like you're trying to import an npm module. This is only supported via CDNs like esm.sh. Have you tried 'import mod from "https://esm.sh/p-retry"'?`,
+    )
+  } finally {
+    await cleanup()
+  }
+})
+
+test('Prints a nice error message when user tries importing NPM module with npm: scheme', async () => {
+  expect.assertions(2)
+
+  const { basePath, cleanup, distPath } = await useFixture('imports_npm_module_scheme')
+  const sourceDirectory = join(basePath, 'functions')
+  const declarations = [
+    {
+      function: 'func1',
+      path: '/func1',
+    },
+  ]
+
+  try {
+    await bundle([sourceDirectory], distPath, declarations, { basePath })
+  } catch (error) {
+    expect(error).toBeInstanceOf(BundleError)
+    expect((error as BundleError).message).toEqual(
+      `It seems like you're trying to import an npm module. This is only supported via CDNs like esm.sh. Have you tried 'import mod from "https://esm.sh/p-retry"'?`,
     )
   } finally {
     await cleanup()

--- a/node/npm_import_error.ts
+++ b/node/npm_import_error.ts
@@ -1,7 +1,7 @@
 class NPMImportError extends Error {
   constructor(originalError: Error, moduleName: string) {
     super(
-      `It seems like you're trying to import an npm module. This is only supported in Deno via CDNs like esm.sh. Have you tried 'import mod from "https://esm.sh/${moduleName}"'?`,
+      `It seems like you're trying to import an npm module. This is only supported via CDNs like esm.sh. Have you tried 'import mod from "https://esm.sh/${moduleName}"'?`,
     )
 
     this.name = 'NPMImportError'
@@ -17,6 +17,12 @@ const wrapNpmImportError = (input: unknown) => {
     const match = input.message.match(/Relative import path "(.*)" not prefixed with/)
     if (match !== null) {
       const [, moduleName] = match
+      return new NPMImportError(input, moduleName)
+    }
+
+    const schemeMatch = input.message.match(/Error: Module not found "npm:(.*)"/)
+    if (schemeMatch !== null) {
+      const [, moduleName] = schemeMatch
       return new NPMImportError(input, moduleName)
     }
   }

--- a/test/fixtures/imports_npm_module_scheme/functions/func1.ts
+++ b/test/fixtures/imports_npm_module_scheme/functions/func1.ts
@@ -1,0 +1,1 @@
+import pRetry from "npm:p-retry"


### PR DESCRIPTION
We're already printing a nice error message for npm imports. We should do the same for `npm:`-prefixed imports.

discovered in https://netlify.slack.com/archives/C02BUDF7A4B/p1671250384449859