### PR TITLE
feat!: make `config` export a plain object

### DIFF
--- a/deno/config.ts
+++ b/deno/config.ts
@@ -19,22 +19,12 @@ if (func.config === undefined) {
   Deno.exit(exitCodes.NoConfig)
 }
 
-if (typeof func.config !== 'function') {
+if (typeof func.config !== 'object') {
   Deno.exit(exitCodes.InvalidExport)
 }
 
-let config
-
 try {
-  config = await func.config()
-} catch (error) {
-  console.error(error)
-
-  Deno.exit(exitCodes.RuntimeError)
-}
-
-try {
-  const result = JSON.stringify(config)
+  const result = JSON.stringify(func.config)
 
   await Deno.writeTextFile(new URL(collectorURL), result)
 } catch (error) {

--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -45,7 +45,7 @@ test('`getFunctionConfig` extracts configuration properties from function file',
       source: `
         export default async () => new Response("Hello from function two")
 
-        export const config = () => ({})
+        export const config = {}
       `,
     },
 
@@ -56,9 +56,9 @@ test('`getFunctionConfig` extracts configuration properties from function file',
       source: `
       export default async () => new Response("Hello from function two")
 
-      export const config = {}
+      export const config = () => ({})
     `,
-      userLog: /^'config' export in edge function at '(.*)' must be a function$/,
+      userLog: /^'config' export in edge function at '(.*)' must be an object$/,
     },
 
     // Config with a syntax error
@@ -73,20 +73,6 @@ test('`getFunctionConfig` extracts configuration properties from function file',
       userLog: /^Could not load edge function at '(.*)'$/,
     },
 
-    // Config that throws
-    {
-      expectedConfig: {},
-      name: 'func5',
-      source: `
-          export default async () => new Response("Hello from function two")
-
-          export const config = () => {
-            throw new Error('uh-oh')
-          }
-        `,
-      userLog: /^Error while running 'config' function in edge function at '(.*)'$/,
-    },
-
     // Config with `path`
     {
       expectedConfig: { path: '/home' },
@@ -94,24 +80,8 @@ test('`getFunctionConfig` extracts configuration properties from function file',
       source: `
         export default async () => new Response("Hello from function three")
 
-        export const config = () => ({ path: "/home" })
+        export const config = { path: "/home" }
       `,
-    },
-
-    // Config that prints to stdout
-    {
-      expectedConfig: { path: '/home' },
-      name: 'func7',
-      source: `
-        export default async () => new Response("Hello from function three")
-
-        export const config = () => {
-          console.log("Hello from config!")
-
-          return { path: "/home" }
-        }
-      `,
-      userLog: /^Hello from config!$/,
     },
   ]
 

--- a/node/config.ts
+++ b/node/config.ts
@@ -17,7 +17,6 @@ enum ConfigExitCode {
   ImportError,
   NoConfig,
   InvalidExport,
-  RuntimeError,
   SerializationError,
   InvalidDefaultExport,
 }
@@ -108,18 +107,12 @@ const logConfigError = (func: EdgeFunction, exitCode: number, stderr: string, lo
       break
 
     case ConfigExitCode.InvalidExport:
-      log.user(`'config' export in edge function at '${func.path}' must be a function`)
-
-      break
-
-    case ConfigExitCode.RuntimeError:
-      log.user(`Error while running 'config' function in edge function at '${func.path}'`)
-      log.user(stderr)
+      log.user(`'config' export in edge function at '${func.path}' must be an object`)
 
       break
 
     case ConfigExitCode.SerializationError:
-      log.user(`'config' function in edge function at '${func.path}' must return an object with primitive values only`)
+      log.user(`'config' object in edge function at '${func.path}' must contain primitive values only`)
 
       break
 

--- a/test/fixtures/serve_test/netlify/edge-functions/echo_env.ts
+++ b/test/fixtures/serve_test/netlify/edge-functions/echo_env.ts
@@ -4,6 +4,6 @@ import { yell } from 'helper'
 
 export default () => new Response(yell(Deno.env.get('very_secret_secret') ?? ''))
 
-export const config: Config = () => ({
+export const config: Config = {
   path: '/my-function',
-})
+}

--- a/test/fixtures/with_config/.netlify/edge-functions/framework-func1.ts
+++ b/test/fixtures/with_config/.netlify/edge-functions/framework-func1.ts
@@ -6,6 +6,6 @@ export default async () => {
   return new Response(greeting)
 }
 
-export const config = () => ({
+export const config = {
   path: '/framework-func1',
-})
+}

--- a/test/fixtures/with_config/netlify/edge-functions/user-func1.ts
+++ b/test/fixtures/with_config/netlify/edge-functions/user-func1.ts
@@ -11,6 +11,6 @@ export default async () => {
   return new Response(greeting)
 }
 
-export const config = () => ({
+export const config = {
   path: '/user-func1',
-})
+}

--- a/test/fixtures/with_config/netlify/edge-functions/user-func3.ts
+++ b/test/fixtures/with_config/netlify/edge-functions/user-func3.ts
@@ -1,6 +1,6 @@
 export default async () => new Response('Hello from user function 3')
 
-export const config = () => ({
+export const config = {
   cache: 'not_a_supported_value',
   path: '/user-func3',
-})
+}

--- a/test/fixtures/with_config/netlify/edge-functions/user-func4.ts
+++ b/test/fixtures/with_config/netlify/edge-functions/user-func4.ts
@@ -5,7 +5,7 @@ export default async () =>
     },
   })
 
-export const config = () => ({
+export const config = {
   cache: 'manual',
   path: '/user-func4',
-})
+}


### PR DESCRIPTION
**Which problem is this pull request solving?**

Changes the `config` export to expect a plain object instead of a function that returns an object.

**List other issues or pull requests related to this problem**

https://github.com/netlify/pod-compute/issues/323#issuecomment-1360564040