### PR TITLE
fix: replace "items" with "additionalProperties"

### DIFF
--- a/node/validation/manifest/schema.ts
+++ b/node/validation/manifest/schema.ts
@@ -73,7 +73,7 @@ const edgeManifestSchema = {
     },
     import_map: { type: 'string' },
     bundler_version: { type: 'string' },
-    function_config: { type: 'object', items: functionConfigSchema },
+    function_config: { type: 'object', additionalProperties: functionConfigSchema },
   },
   additionalProperties: false,
 }


### PR DESCRIPTION
We're currently printing the warning `strict mode: missing type "array" for keyword "items" at "#/properties/function_config" (strictTypes)`. This PR fixes that. Apparently `items` is restricted to use with `type: "array"`, the equivalent is `additionalProperties: ...` (which is the same as `properties: { ".*": ... }`.
