### PR TITLE
feat: rename x-deno- to x-nf- headers

### DIFF
--- a/node/formats/javascript.ts
+++ b/node/formats/javascript.ts
@@ -8,7 +8,7 @@ import { deleteAsync } from 'del'
 import { EdgeFunction } from '../edge_function.js'
 import type { FormatFunction } from '../server/server.js'
 
-const BOOTSTRAP_LATEST = 'https://63c01cf32d59e80008a857fc--edge.netlify.com/bootstrap/index-combined.ts'
+const BOOTSTRAP_LATEST = 'https://63c67470ca761b0008582aff--edge.netlify.com/bootstrap/index-combined.ts'
 
 const defaultFormatExportTypeError: FormatFunction = (name) =>
   `The Edge Function "${name}" has failed to load. Does it have a function as the default export?`

--- a/node/server/server.test.ts
+++ b/node/server/server.test.ts
@@ -56,8 +56,8 @@ test('Starts a server and serves requests for edge functions', async () => {
 
   const response1 = await fetch(`http://0.0.0.0:${port}/foo`, {
     headers: {
-      'x-deno-functions': 'echo_env',
-      'x-deno-pass': 'passthrough',
+      'x-nf-edge-functions': 'echo_env',
+      'x-ef-passthrough': 'passthrough',
       'X-NF-Request-ID': uuidv4(),
     },
   })
@@ -66,8 +66,8 @@ test('Starts a server and serves requests for edge functions', async () => {
 
   const response2 = await fetch(`http://0.0.0.0:${port}/greet`, {
     headers: {
-      'x-deno-functions': 'greet',
-      'x-deno-pass': 'passthrough',
+      'x-nf-edge-functions': 'greet',
+      'x-ef-passthrough': 'passthrough',
       'X-NF-Request-ID': uuidv4(),
     },
   })


### PR DESCRIPTION
Part of https://github.com/netlify/partner-deno/issues/11. This renames `x-deno-` headers to `x-nf-` headers.

Tests fail right now, but will pass once https://github.com/netlify/edge-functions-bootstrap/pull/155 lands.