### PR TITLE
feat: validate pattern declarations

### DIFF
--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -78,8 +78,9 @@ export const getDeclarationsFromConfig = (
 }
 
 // Validates and normalizes a pattern so that it's a valid regular expression
-// for the Go regexp engine.
+// in Go, which is the engine used by our edge nodes.
 export const parsePattern = (pattern: string) => {
+  // Escaping forward slashes with back slashes.
   const normalizedPattern = pattern.replace(/\//g, '\\/')
   const regex = regexpAST.transform(`/${normalizedPattern}/`, {
     Assertion(path) {

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -86,7 +86,7 @@ export const parsePattern = (pattern: string) => {
     Assertion(path) {
       // Lookaheads are not supported. If we find one, throw an error.
       if (path.node.kind === 'Lookahead') {
-        throw new Error('Regular expressions with negative lookaheads are not supported')
+        throw new Error('Regular expressions with lookaheads are not supported')
       }
     },
 

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -1,4 +1,4 @@
-import { transform } from 'regexp-tree'
+import regexpAST from 'regexp-tree'
 
 import { FunctionConfig } from './config.js'
 import type { DeployConfig } from './deploy_config.js'
@@ -81,7 +81,7 @@ export const getDeclarationsFromConfig = (
 // for the Go regexp engine.
 export const parsePattern = (pattern: string) => {
   const normalizedPattern = pattern.replace(/\//g, '\\/')
-  const regex = transform(`/${normalizedPattern}/`, {
+  const regex = regexpAST.transform(`/${normalizedPattern}/`, {
     Assertion(path) {
       // Lookaheads are not supported. If we find one, throw an error.
       if (path.node.kind === 'Lookahead') {

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -1,3 +1,5 @@
+import { transform } from 'regexp-tree'
+
 import { FunctionConfig } from './config.js'
 import type { DeployConfig } from './deploy_config.js'
 
@@ -73,6 +75,36 @@ export const getDeclarationsFromConfig = (
   }
 
   return declarations
+}
+
+// Validates and normalizes a pattern so that it's a valid regular expression
+// for the Go regexp engine.
+export const parsePattern = (pattern: string) => {
+  const normalizedPattern = pattern.replace(/\//g, '\\/')
+  const regex = transform(`/${normalizedPattern}/`, {
+    Assertion(path) {
+      // Lookaheads are not supported. If we find one, throw an error.
+      if (path.node.kind === 'Lookahead') {
+        throw new Error('Regular expressions with negative lookaheads are not supported')
+      }
+    },
+
+    Group(path) {
+      // Named captured groups in JavaScript use a different syntax than in Go.
+      // If we find one, convert it to an unnamed capture group, which is valid
+      // in both engines.
+      if ('name' in path.node && path.node.name !== undefined) {
+        path.replace({
+          ...path.node,
+          name: undefined,
+          nameRaw: undefined,
+        })
+      }
+    },
+  })
+
+  // Strip leading and forward slashes.
+  return regex.toString().slice(1, -1)
 }
 
 export { Declaration, DeclarationWithPath, DeclarationWithPattern }

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -197,7 +197,7 @@ test('Throws an error if the regular expression contains a negative lookahead', 
   const declarations = [{ function: 'func-1', pattern: '^/\\w+(?=\\d)$' }]
 
   expect(() => generateManifest({ bundles: [], declarations, functions })).toThrowError(
-    /^Could not parse path declaration of function 'func-1': Regular expressions with negative lookaheads are not supported$/,
+    /^Could not parse path declaration of function 'func-1': Regular expressions with lookaheads are not supported$/,
   )
 })
 

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -191,3 +191,20 @@ test('Generates a manifest with layers', () => {
   expect(manifest2.routes).toEqual(expectedRoutes)
   expect(manifest2.layers).toEqual(layers)
 })
+
+test('Throws an error if the regular expression contains a negative lookahead', () => {
+  const functions = [{ name: 'func-1', path: '/path/to/func-1.ts' }]
+  const declarations = [{ function: 'func-1', pattern: '^/\\w+(?=\\d)$' }]
+
+  expect(() => generateManifest({ bundles: [], declarations, functions })).toThrowError(
+    /^Could not parse path declaration of function 'func-1': Regular expressions with negative lookaheads are not supported$/,
+  )
+})
+
+test('Converts named capture groups to unnamed capture groups in regular expressions', () => {
+  const functions = [{ name: 'func-1', path: '/path/to/func-1.ts' }]
+  const declarations = [{ function: 'func-1', pattern: '^/(?<name>\\w+)$' }]
+  const manifest = generateManifest({ bundles: [], declarations, functions })
+
+  expect(manifest.routes).toEqual([{ function: 'func-1', pattern: '^/(\\w+)$' }])
+})

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -5,7 +5,7 @@ import globToRegExp from 'glob-to-regexp'
 
 import type { Bundle } from './bundle.js'
 import { Cache, FunctionConfig } from './config.js'
-import type { Declaration } from './declaration.js'
+import { Declaration, parsePattern } from './declaration.js'
 import { EdgeFunction } from './edge_function.js'
 import { Layer } from './layer.js'
 import { getPackageVersion } from './package_json.js'
@@ -47,7 +47,11 @@ interface Route {
   pattern: string
 }
 
-const serializePattern = (regex: RegExp) => regex.source.replace(/\\\//g, '/')
+// JavaScript regular expressions are converted to strings with leading and
+// trailing slashes, so any slashes inside the expression itself are escaped
+// as `//`. This function deserializes that back into a single slash, which
+// is the format we want to use in the manifest.
+const serializePattern = (pattern: string) => pattern.replace(/\\\//g, '/')
 
 const sanitizeEdgeFunctionConfig = (config: Record<string, EdgeFunctionConfig>): Record<string, EdgeFunctionConfig> => {
   const newConfig: Record<string, EdgeFunctionConfig> = {}
@@ -78,7 +82,7 @@ const generateManifest = ({
   for (const [name, { excludedPath }] of Object.entries(functionConfig)) {
     if (excludedPath) {
       const paths = Array.isArray(excludedPath) ? excludedPath : [excludedPath]
-      const excludedPatterns = paths.map(pathToRegularExpression).map(serializePattern)
+      const excludedPatterns = paths.map(pathToRegularExpression)
       manifestFunctionConfig[name].excluded_patterns.push(...excludedPatterns)
     }
   }
@@ -97,6 +101,7 @@ const generateManifest = ({
       pattern: serializePattern(pattern),
     }
     const excludedPattern = getExcludedRegularExpression(declaration)
+
     if (excludedPattern) {
       manifestFunctionConfig[func.name].excluded_patterns.push(serializePattern(excludedPattern))
     }
@@ -134,12 +139,18 @@ const pathToRegularExpression = (path: string) => {
   // for both `/foo` and `/foo/`.
   const normalizedSource = `^${regularExpression.source}\\/?$`
 
-  return new RegExp(normalizedSource)
+  return normalizedSource
 }
 
 const getRegularExpression = (declaration: Declaration) => {
   if ('pattern' in declaration) {
-    return new RegExp(declaration.pattern)
+    try {
+      return parsePattern(declaration.pattern)
+    } catch (error: unknown) {
+      throw new Error(
+        `Could not parse path declaration of function '${declaration.function}': ${(error as Error).message}`,
+      )
+    }
   }
 
   return pathToRegularExpression(declaration.path)
@@ -147,7 +158,7 @@ const getRegularExpression = (declaration: Declaration) => {
 
 const getExcludedRegularExpression = (declaration: Declaration) => {
   if ('pattern' in declaration && declaration.excludedPattern) {
-    return new RegExp(declaration.excludedPattern)
+    return parsePattern(declaration.excludedPattern)
   }
 
   if ('path' in declaration && declaration.excludedPath) {

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -159,7 +159,13 @@ const getRegularExpression = (declaration: Declaration) => {
 
 const getExcludedRegularExpression = (declaration: Declaration) => {
   if ('pattern' in declaration && declaration.excludedPattern) {
-    return parsePattern(declaration.excludedPattern)
+    try {
+      return parsePattern(declaration.excludedPattern)
+    } catch (error: unknown) {
+      throw new Error(
+        `Could not parse path declaration of function '${declaration.function}': ${(error as Error).message}`,
+      )
+    }
   }
 
   if ('path' in declaration && declaration.excludedPath) {

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -158,7 +158,7 @@ const getRegularExpression = (declaration: Declaration) => {
 }
 
 const getExcludedRegularExpression = (declaration: Declaration) => {
-  if ('pattern' in declaration && declaration.excludedPattern) {
+  if ('excludedPattern' in declaration && declaration.excludedPattern) {
     try {
       return parsePattern(declaration.excludedPattern)
     } catch (error: unknown) {

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -82,7 +82,8 @@ const generateManifest = ({
   for (const [name, { excludedPath }] of Object.entries(functionConfig)) {
     if (excludedPath) {
       const paths = Array.isArray(excludedPath) ? excludedPath : [excludedPath]
-      const excludedPatterns = paths.map(pathToRegularExpression)
+      const excludedPatterns = paths.map(pathToRegularExpression).map(serializePattern)
+
       manifestFunctionConfig[name].excluded_patterns.push(...excludedPatterns)
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "p-retry": "^5.1.1",
         "p-wait-for": "^4.1.0",
         "path-key": "^4.0.0",
+        "regexp-tree": "^0.1.24",
         "semver": "^7.3.5",
         "tmp-promise": "^3.0.3",
         "uuid": "^9.0.0"
@@ -7851,7 +7852,6 @@
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
       "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
-      "dev": true,
       "bin": {
         "regexp-tree": "bin/regexp-tree"
       }
@@ -14658,8 +14658,7 @@
     "regexp-tree": {
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
-      "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
-      "dev": true
+      "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "p-retry": "^5.1.1",
     "p-wait-for": "^4.1.0",
     "path-key": "^4.0.0",
+    "regexp-tree": "^0.1.24",
     "semver": "^7.3.5",
     "tmp-promise": "^3.0.3",
     "uuid": "^9.0.0"


### PR DESCRIPTION
**Which problem is this pull request solving?**

This PR parses into an AST any paths defined as regular expressions and:

1. Throws an error if they contain negative lookaheads, as they aren't supported by the Go engine
2. Converts named captured groups into regular captured groups, since the JavaScript syntax for named captured groups is different than the one used by the Go engine

**List other issues or pull requests related to this problem**

Supersedes #226.