### PR TITLE
chore: migrate to Github Action's output files

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -48,8 +48,8 @@ jobs:
         run: |-
           os=${{ matrix.os }}
           node=${{ matrix.node-version }}
-          echo "::set-output name=os::${os/-latest/}"
-          echo "::set-output name=node::node_${node//[.*]/}"
+          echo "os=${os/-latest/}" >> $GITHUB_OUTPUT
+          echo "node=node_${node//[.*]/}" >> $GITHUB_OUTPUT
         shell: bash
       - uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for context.
