### PR TITLE
feat: add generator field to edge function manifest

### DIFF
--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -7,6 +7,7 @@ interface BaseDeclaration {
   cache?: string
   function: string
   name?: string
+  generator?: string
 }
 
 type DeclarationWithPath = BaseDeclaration & {

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -52,6 +52,31 @@ test('Generates a manifest with display names', () => {
   expect(manifest.bundler_version).toBe(env.npm_package_version as string)
 })
 
+test('Generates a manifest with a generator field', () => {
+  const functions = [
+    { name: 'func-1', path: '/path/to/func-1.ts' },
+    { name: 'func-2', path: '/path/to/func-2.ts' },
+    { name: 'func-3', path: '/path/to/func-3.ts' },
+  ]
+
+  const declarations = [
+    { function: 'func-1', generator: '@netlify/fake-plugin@1.0.0', path: '/f1/*' },
+    { function: 'func-2', path: '/f2/*' },
+    { function: 'func-3', generator: '@netlify/fake-plugin@1.0.0', cache: 'manual', path: '/f3' },
+  ]
+  const manifest = generateManifest({ bundles: [], declarations, functions })
+
+  const expectedRoutes = [
+    { function: 'func-1', generator: '@netlify/fake-plugin@1.0.0', pattern: '^/f1/.*/?$' },
+    { function: 'func-2', pattern: '^/f2/.*/?$' },
+  ]
+  const expectedPostCacheRoutes = [{ function: 'func-3', generator: '@netlify/fake-plugin@1.0.0', pattern: '^/f3/?$' }]
+
+  expect(manifest.routes).toEqual(expectedRoutes)
+  expect(manifest.post_cache_routes).toEqual(expectedPostCacheRoutes)
+  expect(manifest.bundler_version).toBe(env.npm_package_version as string)
+})
+
 test('Generates a manifest with excluded paths and patterns', () => {
   const functions = [
     { name: 'func-1', path: '/path/to/func-1.ts' },

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -17,6 +17,7 @@ interface Route {
   function: string
   name?: string
   pattern: string
+  generator?: string
 }
 interface EdgeFunctionConfig {
   excluded_patterns: string[]
@@ -47,6 +48,7 @@ interface Route {
   function: string
   name?: string
   pattern: string
+  generator?: string
 }
 
 // JavaScript regular expressions are converted to strings with leading and
@@ -103,6 +105,7 @@ const generateManifest = ({
       function: func.name,
       name: declaration.name,
       pattern: serializePattern(pattern),
+      generator: declaration.generator,
     }
     const excludedPattern = getExcludedRegularExpression(
       declaration,


### PR DESCRIPTION
🎉 Thanks for sending this pull request! 🎉

**Which problem is this pull request solving?**

Allows edge function to have a generator field in the manifest. It adds generator to the Declaration, which is the config that plugins write and then forwards this generator field to the edge manifest.

**List other issues or pull requests related to this problem**

Work on https://github.com/netlify/pod-compute/issues/415
![cute cat with glasses on](https://media.giphy.com/media/xT77XZrTKOxycjaYvK/giphy.gif)