### PR TITLE
fix: ignore config blocks for undefined functions

### DIFF
--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -77,6 +77,11 @@ const generateManifest = ({
   )
 
   for (const [name, { excludedPath, onError }] of Object.entries(functionConfig)) {
+    // If the config block is for a function that is not defined, discard it.
+    if (manifestFunctionConfig[name] === undefined) {
+      continue
+    }
+
     if (excludedPath) {
       const paths = Array.isArray(excludedPath) ? excludedPath : [excludedPath]
       const excludedPatterns = paths.map(pathToRegularExpression).map(serializePattern)


### PR DESCRIPTION
**Which problem is this pull request solving?**

This fixes a problem where a config block for a function that doesn't have a declaration throws an error, because `manifestFunctionConfig[name]` will be `undefined`. This PR adds a check for that.