### PR TITLE
feat: add `@netlify/edge-functions` as new import specifier for edge bootstrap

### DIFF
--- a/deno/lib/consts.ts
+++ b/deno/lib/consts.ts
@@ -1,4 +1,5 @@
-export const PUBLIC_SPECIFIER = 'netlify:edge'
+export const OLD_PUBLIC_SPECIFIER = 'netlify:edge'
+export const PUBLIC_SPECIFIER = '@netlify/edge-functions'
 export const STAGE1_SPECIFIER = 'netlify:bootstrap-stage1'
 export const STAGE2_SPECIFIER = 'netlify:bootstrap-stage2'
 export const virtualRoot = 'file:///root/'

--- a/deno/lib/stage2.ts
+++ b/deno/lib/stage2.ts
@@ -6,6 +6,7 @@ import type { InputFunction, WriteStage2Options } from '../../shared/stage2.ts'
 import { importMapSpecifier, virtualRoot } from '../../shared/consts.ts'
 import { PUBLIC_SPECIFIER, STAGE2_SPECIFIER } from './consts.ts'
 import { inlineModule, loadFromVirtualRoot, loadWithRetry } from './common.ts'
+import { OLD_PUBLIC_SPECIFIER } from './consts'
 
 interface FunctionReference {
   exportLine: string
@@ -75,7 +76,7 @@ const stage2Loader = (basePath: string, functions: InputFunction[], externals: S
       return inlineModule(specifier, importMapData)
     }
 
-    if (specifier === PUBLIC_SPECIFIER || externals.has(specifier)) {
+    if (specifier === PUBLIC_SPECIFIER || specifier === OLD_PUBLIC_SPECIFIER || externals.has(specifier)) {
       return {
         kind: 'external',
         specifier,

--- a/node/import_map.test.ts
+++ b/node/import_map.test.ts
@@ -27,6 +27,7 @@ test('Handles import maps with full URLs without specifying a base URL', () => {
   const { imports } = map.getContents()
 
   expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
+  expect(imports['@netlify/edge-functions']).toBe('https://edge.netlify.com/v1/index.ts')
   expect(imports['alias:jamstack']).toBe('https://jamstack.org/')
   expect(imports['alias:pets']).toBe('https://petsofnetlify.com/')
 })
@@ -45,6 +46,7 @@ test('Resolves relative paths to absolute paths if a base path is not provided',
   const expectedPath = join(cwd(), 'my-cool-site', 'heart', 'pets')
 
   expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
+  expect(imports['@netlify/edge-functions']).toBe('https://edge.netlify.com/v1/index.ts')
   expect(imports['alias:pets']).toBe(`${pathToFileURL(expectedPath).toString()}/`)
 })
 
@@ -62,6 +64,7 @@ test('Transforms relative paths so that they become relative to the base path', 
   const { imports: imports1 } = map1.getContents(cwd())
 
   expect(imports1['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
+  expect(imports1['@netlify/edge-functions']).toBe('https://edge.netlify.com/v1/index.ts')
   expect(imports1['alias:pets']).toBe('file:///my-cool-site/heart/pets/')
 
   // With a prefix.
@@ -69,6 +72,7 @@ test('Transforms relative paths so that they become relative to the base path', 
   const { imports: imports2 } = map2.getContents(cwd(), 'file:///root/')
 
   expect(imports2['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
+  expect(imports2['@netlify/edge-functions']).toBe('https://edge.netlify.com/v1/index.ts')
   expect(imports2['alias:pets']).toBe('file:///root/my-cool-site/heart/pets/')
 })
 
@@ -109,5 +113,6 @@ test('Writes import map file to disk', async () => {
   await file.cleanup()
 
   expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
+  expect(imports['@netlify/edge-functions']).toBe('https://edge.netlify.com/v1/index.ts')
   expect(imports['alias:pets']).toBe(pathToFileURL(expectedPath).toString())
 })

--- a/node/import_map.ts
+++ b/node/import_map.ts
@@ -10,6 +10,7 @@ import { isFileNotFoundError } from './utils/error.js'
 
 const INTERNAL_IMPORTS = {
   'netlify:edge': 'https://edge.netlify.com/v1/index.ts',
+  '@netlify/edge-functions': 'https://edge.netlify.com/v1/index.ts',
 }
 
 type Imports = Record<string, string>


### PR DESCRIPTION
This fixes https://github.com/netlify/pod-compute/issues/417

It adds a new specifier `@netlify/edge-functions` as alternative to `netlift:edge` and the actual URL.