### PR TITLE
fix: change the order of how edge functions are written to the manifest

### DIFF
--- a/node/__snapshots__/declaration.test.ts.snap
+++ b/node/__snapshots__/declaration.test.ts.snap
@@ -1,37 +1,90 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Deploy config takes precedence over user config 1`] = `
+exports[`Ensure the order of edge functions with FF 1`] = `
 [
   {
-    "function": "user-a",
+    "function": "framework-manifest-a",
     "path": "/path1",
   },
   {
-    "function": "user-b",
+    "function": "framework-manifest-c",
+    "path": "/path3",
+  },
+  {
+    "function": "framework-manifest-b",
     "path": "/path2",
   },
   {
-    "function": "framework-a",
+    "function": "framework-isc-c",
     "path": "/path1",
   },
   {
-    "function": "framework-b",
+    "function": "framework-isc-c",
     "path": "/path2",
   },
   {
-    "function": "framework-c",
+    "function": "user-toml-a",
     "path": "/path1",
   },
   {
-    "function": "framework-c",
+    "function": "user-toml-c",
+    "path": "/path3",
+  },
+  {
+    "function": "user-toml-b",
     "path": "/path2",
   },
   {
-    "function": "user-c",
+    "function": "user-isc-c",
     "path": "/path1",
   },
   {
-    "function": "user-c",
+    "function": "user-isc-c",
+    "path": "/path2",
+  },
+]
+`;
+
+exports[`Ensure the order of edge functions without FF 1`] = `
+[
+  {
+    "function": "user-toml-a",
+    "path": "/path1",
+  },
+  {
+    "function": "user-toml-c",
+    "path": "/path3",
+  },
+  {
+    "function": "user-toml-b",
+    "path": "/path2",
+  },
+  {
+    "function": "framework-manifest-a",
+    "path": "/path1",
+  },
+  {
+    "function": "framework-manifest-c",
+    "path": "/path3",
+  },
+  {
+    "function": "framework-manifest-b",
+    "path": "/path2",
+  },
+  {
+    "function": "framework-isc-c",
+    "path": "/path1",
+  },
+  {
+    "function": "framework-isc-c",
+    "path": "/path2",
+  },
+  {
+    "function": "user-isc-c",
+    "path": "/path1",
+  },
+  {
+    "function": "user-isc-c",
     "path": "/path2",
   },
 ]

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -131,6 +131,7 @@ const bundle = async (
     userFunctionsWithConfig,
     internalFunctionsWithConfig,
     deployConfig.declarations,
+    featureFlags,
   )
 
   const internalFunctionConfig = createFunctionConfig({

--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -5,26 +5,60 @@ import { Declaration, mergeDeclarations } from './declaration.js'
 
 const deployConfigDeclarations: Declaration[] = []
 
-test('Deploy config takes precedence over user config', () => {
+test('Ensure the order of edge functions with FF', () => {
   const deployConfigDeclarations: Declaration[] = [
-    { function: 'framework-a', path: '/path1' },
-    { function: 'framework-b', path: '/path2' },
+    { function: 'framework-manifest-a', path: '/path1' },
+    { function: 'framework-manifest-c', path: '/path3' },
+    { function: 'framework-manifest-b', path: '/path2' },
   ]
 
   const tomlConfig: Declaration[] = [
-    { function: 'user-a', path: '/path1' },
-    { function: 'user-b', path: '/path2' },
+    { function: 'user-toml-a', path: '/path1' },
+    { function: 'user-toml-c', path: '/path3' },
+    { function: 'user-toml-b', path: '/path2' },
   ]
 
   const userFuncConfig = {
-    'user-c': { path: ['/path1', '/path2'] },
+    'user-isc-c': { path: ['/path1', '/path2'] },
   } as Record<string, FunctionConfig>
 
   const internalFuncConfig = {
-    'framework-c': { path: ['/path1', '/path2'] },
+    'framework-isc-c': { path: ['/path1', '/path2'] },
   } as Record<string, FunctionConfig>
 
-  expect(mergeDeclarations(tomlConfig, userFuncConfig, internalFuncConfig, deployConfigDeclarations)).toMatchSnapshot()
+  expect(
+    mergeDeclarations(tomlConfig, userFuncConfig, internalFuncConfig, deployConfigDeclarations, {
+      edge_functions_correct_order: true,
+    }),
+  ).toMatchSnapshot()
+})
+
+test('Ensure the order of edge functions without FF', () => {
+  const deployConfigDeclarations: Declaration[] = [
+    { function: 'framework-manifest-a', path: '/path1' },
+    { function: 'framework-manifest-c', path: '/path3' },
+    { function: 'framework-manifest-b', path: '/path2' },
+  ]
+
+  const tomlConfig: Declaration[] = [
+    { function: 'user-toml-a', path: '/path1' },
+    { function: 'user-toml-c', path: '/path3' },
+    { function: 'user-toml-b', path: '/path2' },
+  ]
+
+  const userFuncConfig = {
+    'user-isc-c': { path: ['/path1', '/path2'] },
+  } as Record<string, FunctionConfig>
+
+  const internalFuncConfig = {
+    'framework-isc-c': { path: ['/path1', '/path2'] },
+  } as Record<string, FunctionConfig>
+
+  expect(
+    mergeDeclarations(tomlConfig, userFuncConfig, internalFuncConfig, deployConfigDeclarations, {
+      edge_functions_correct_order: false,
+    }),
+  ).toMatchSnapshot()
 })
 
 test('In-source config takes precedence over netlify.toml config', () => {

--- a/node/feature_flags.ts
+++ b/node/feature_flags.ts
@@ -1,4 +1,5 @@
 const defaultFlags = {
+  edge_functions_correct_order: false,
   edge_functions_fail_unsupported_regex: false,
   edge_functions_invalid_config_throw: false,
   edge_functions_manifest_validate_slash: false,


### PR DESCRIPTION
This changes the order of edge functions to

1. Framework functions defined in `manifest.json` (if the functions have ISC the info will overwrite settings from manifest.json)
2. Framework functions not defined in `manifest.json` but that have ISC
3. User functions defined in TOML (if the functions have ISC the info will overwrite settings from manifest.json)
4. User functions not defined in TOML but have ISC.

Fixes: https://github.com/netlify/pod-compute/issues/442