### PR TITLE
fix: remove duplicate functions and let .js take precedence

### DIFF
--- a/node/finder.test.ts
+++ b/node/finder.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from 'vitest'
+
+import { removeDuplicatesByExtension } from './finder.js'
+
+test('filters out any duplicate files based on the extension', () => {
+  const functions = [
+    'file1.js',
+    'file1.ts',
+    'file2.tsx',
+    'file2.jsx',
+    'file3.tsx',
+    'file3.js',
+    'file4.ts',
+    'file5.ts',
+    'file5.tsx',
+  ]
+  const expected = ['file1.js', 'file2.jsx', 'file3.js', 'file4.ts', 'file5.ts']
+
+  expect(removeDuplicatesByExtension(functions)).toStrictEqual(expected)
+})

--- a/node/finder.ts
+++ b/node/finder.ts
@@ -8,27 +8,29 @@ import { nonNullable } from './utils/non_nullable.js'
 // with a lower index meaning a higher precedence over the others
 const ALLOWED_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx']
 
-const removeDuplicatesByExtension = (functions: string[]) => {
+export const removeDuplicatesByExtension = (functions: string[]) => {
   const seen = new Map()
 
-  return functions.reduce((acc, path) => {
-    const { ext, name } = parse(path)
-    const extIndex = [...ALLOWED_EXTENSIONS].indexOf(ext)
+  return Object.values(
+    functions.reduce((acc, path) => {
+      const { ext, name } = parse(path)
+      const extIndex = ALLOWED_EXTENSIONS.indexOf(ext)
 
-    if (!seen.has(name) || seen.get(name) > extIndex) {
-      seen.set(name, extIndex)
-      return [...acc, path]
-    }
+      if (!seen.has(name) || seen.get(name) > extIndex) {
+        seen.set(name, extIndex)
+        return { ...acc, [name]: path }
+      }
 
-    return acc
-  }, [] as string[])
+      return acc
+    }, {}),
+  ) as string[]
 }
 
 const findFunctionInDirectory = async (directory: string): Promise<EdgeFunction | undefined> => {
   const name = basename(directory)
-  const candidatePaths = [...ALLOWED_EXTENSIONS]
-    .flatMap((extension) => [`${name}${extension}`, `index${extension}`])
-    .map((filename) => join(directory, filename))
+  const candidatePaths = ALLOWED_EXTENSIONS.flatMap((extension) => [`${name}${extension}`, `index${extension}`]).map(
+    (filename) => join(directory, filename),
+  )
 
   let functionPath
 


### PR DESCRIPTION
Solving: https://github.com/netlify/pod-compute/issues/461

As [documented here](https://docs.netlify.com/edge-functions/get-started/#deploy),

> If a project has TypeScript and JavaScript edge functions with the same name, for example, my-function.ts and my-function.js, the TypeScript function is ignored while the JavaScript function is deployed.

After testing this out, it appears that when deployed, it works the other way around. The typescript function takes precedence over the javascript file.

We need to make sure it is as described in the documentation.

This PR should fix this.