### PR TITLE
feat: add `excluded_patterns` on route level

### DIFF
--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -272,11 +272,13 @@ test('Stores excludedPath in `routes` (flagged)', async () => {
     {
       function: 'user-func2',
       pattern: '^/user-func2/?$',
+      // excludedPath is defined in TOML, so it's stored in `routes`
       excluded_patterns: ['^/user-func2/excluded/?$'],
     },
     { function: 'framework-func1', pattern: '^/framework-func1/?$' },
     { function: 'user-func1', pattern: '^/user-func1/?$' },
     { function: 'user-func3', pattern: '^/user-func3/?$' },
+    // excludedPath is defined in ISC, so it's not here but in in `function_config`
     { function: 'user-func5', pattern: '^/user-func5/.*/?$' },
   ])
 

--- a/node/feature_flags.ts
+++ b/node/feature_flags.ts
@@ -2,6 +2,7 @@ const defaultFlags = {
   edge_functions_correct_order: false,
   edge_functions_fail_unsupported_regex: false,
   edge_functions_invalid_config_throw: false,
+  edge_functions_excluded_patterns_on_route: false,
 }
 
 type FeatureFlag = keyof typeof defaultFlags

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -103,7 +103,7 @@ test('Excluded Paths are written to manifest.routes', () => {
     { function: 'func-2', pattern: '^/f2/.*/?$', excludedPattern: '^/f2/exclude$' },
   ]
   const userFunctionConfig: Record<string, FunctionConfig> = {
-    'func-1': { excludedPath: '/*.css' },
+    'func-1': { path: '/f1/include/*', excludedPath: '/*.css' },
   }
   const internalFunctionConfig: Record<string, FunctionConfig> = {
     'func-2': { excludedPath: '/*.json' },
@@ -120,6 +120,9 @@ test('Excluded Paths are written to manifest.routes', () => {
   expect(manifest.routes).toEqual([
     { function: 'func-1', pattern: '^/f1/.*/?$', excluded_patterns: ['^/f1/exclude/?$'] },
     { function: 'func-2', pattern: '^/f2/.*/?$', excluded_patterns: ['^/f2/exclude$'] },
+    // isc-defined routes are after TOML-defined
+    // doesn't need excluded_patterns, because that lives in function_config
+    { function: 'func-1', pattern: '^/f1/include/.*/?$' },
   ])
   expect(manifest.function_config).toEqual({
     'func-1': { excluded_patterns: ['^/.*\\.css/?$'] },

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -96,16 +96,26 @@ test('Generates a manifest with excluded paths and patterns', () => {
 test('Excluded Paths are written to manifest.routes', () => {
   const functions = [
     { name: 'func-1', path: '/path/to/func-1.ts' },
-    { name: 'func-2', path: '/path/to/func-2.ts' },
+    { name: 'func-2', path: '/path/to/internal/func-2.ts' },
   ]
   const declarations: Declaration[] = [
     { function: 'func-1', path: '/f1/*', excludedPath: '/f1/exclude' },
     { function: 'func-2', pattern: '^/f2/.*/?$', excludedPattern: '^/f2/exclude$' },
   ]
   const userFunctionConfig: Record<string, FunctionConfig> = {
-    'func-1': { excludedPath: '/*.css' }
+    'func-1': { excludedPath: '/*.css' },
   }
-  const manifest = generateManifest({ bundles: [], declarations, functions, userFunctionConfig, featureFlags: { edge_functions_excluded_patterns_on_route: true } })
+  const internalFunctionConfig: Record<string, FunctionConfig> = {
+    'func-2': { excludedPath: '/*.json' },
+  }
+  const manifest = generateManifest({
+    bundles: [],
+    declarations,
+    functions,
+    userFunctionConfig,
+    internalFunctionConfig,
+    featureFlags: { edge_functions_excluded_patterns_on_route: true },
+  })
 
   expect(manifest.routes).toEqual([
     { function: 'func-1', pattern: '^/f1/.*/?$', excluded_patterns: ['^/f1/exclude/?$'] },
@@ -113,6 +123,7 @@ test('Excluded Paths are written to manifest.routes', () => {
   ])
   expect(manifest.function_config).toEqual({
     'func-1': { excluded_patterns: ['^/.*\\.css/?$'] },
+    'func-2': { excluded_patterns: ['^/.*\\.json/?$'] },
   })
 })
 

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -101,6 +101,7 @@ test('Excluded Paths are written to manifest.routes', () => {
   const declarations: Declaration[] = [
     { function: 'func-1', path: '/f1/*', excludedPath: '/f1/exclude' },
     { function: 'func-2', pattern: '^/f2/.*/?$', excludedPattern: '^/f2/exclude$' },
+    { function: 'func-1', pattern: '^/f1/include/.*/?$' },
   ]
   const userFunctionConfig: Record<string, FunctionConfig> = {
     'func-1': { path: '/f1/include/*', excludedPath: '/*.css' },

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -190,7 +190,6 @@ test('Filters out internal in-source configurations in user created functions', 
     },
     'func-2': {
       on_error: 'bypass',
-      cache: Cache.Off,
       name: 'Internal function',
       generator: 'internal-generator',
       excluded_patterns: ['^/f2/exclude/?$'],

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -112,7 +112,9 @@ const generateManifest = ({
     manifestFunctionConfig[name] = { ...manifestFunctionConfig[name], on_error: onError }
   }
 
-  for (const [name, { excludedPath, path, onError, ...rest }] of Object.entries(internalFunctionConfig)) {
+  for (const [name, { excludedPath, cache: _cache, path: _path, onError, ...rest }] of Object.entries(
+    internalFunctionConfig,
+  )) {
     // If the config block is for a function that is not defined, discard it.
     if (manifestFunctionConfig[name] === undefined) {
       continue

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -15,6 +15,7 @@ import { nonNullable } from './utils/non_nullable.js'
 interface Route {
   function: string
   pattern: string
+  excluded_patterns?: string[]
 }
 
 interface EdgeFunctionConfig {
@@ -139,7 +140,11 @@ const generateManifest = ({
     )
 
     if (excludedPattern) {
-      manifestFunctionConfig[func.name].excluded_patterns.push(serializePattern(excludedPattern))
+      if (featureFlags?.edge_functions_excluded_patterns_on_route) {
+        route.excluded_patterns = [serializePattern(excludedPattern)]
+      } else {
+        manifestFunctionConfig[func.name].excluded_patterns.push(serializePattern(excludedPattern))
+      }
     }
 
     if (declaration.cache === Cache.Manual) {


### PR DESCRIPTION
To properly support TOML-defined `exclude_pattern`, this PR adds a new `excluded_patterns` field that lives within `routes`. This is in-line with differentiating function- and route-level configuration: ISC config applies to the function, so it lives in `function_config`, TOML config applies to a route mapping, so it lives in `routes`.

Part of https://github.com/netlify/pod-compute/issues/471.