### PR TITLE
fix: front slashes only get escaped now if they aren't already

### DIFF
--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -209,7 +209,7 @@ test('does not escape front slashes in a regex pattern if they are already escap
   expect(actual).toEqual(expected)
 })
 
-test('escapes front slashes in a regex pattern', () => {
+test('Escapes front slashes in a regex pattern', () => {
   const regexPattern = '^(?:/(_next/data/[^/]{1,}))?(?:/([^/.]{1,}))/shows(?:/(.*))(.json)?[/#\\?]?$'
   const expected = '^(?:\\/(_next\\/data\\/[^\\/]{1,}))?(?:\\/([^\\/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
   const actual = parsePattern(regexPattern)

--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -211,7 +211,7 @@ test('does not escape front slashes in a regex pattern if they are already escap
 
 test('escapes front slashes in a regex pattern', () => {
   const regexPattern = '^(?:/(_next/data/[^/]{1,}))?(?:/([^/.]{1,}))/shows(?:/(.*))(.json)?[/#\\?]?$'
-  const expected = '^(?:\\/(_next\\/data\\/[^\\/]{1,}))?(?:\\/([^\\/.]{1,}))\\/shows(?:\\/(.*))(.json)?[/#\\?]?$'
+  const expected = '^(?:\\/(_next\\/data\\/[^\\/]{1,}))?(?:\\/([^\\/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
   const actual = parsePattern(regexPattern)
 
   expect(actual).toEqual(expected)

--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -209,7 +209,7 @@ test('does not escape front slashes in a regex pattern if they are already escap
   expect(actual).toEqual(expected)
 })
 
-test('escapes front slashes in a regex pattern if they are not already escaped', () => {
+test('escapes front slashes in a regex pattern', () => {
   const regexPattern = '^(?:/(_next/data/[^/]{1,}))?(?:/([^/.]{1,}))/shows(?:/(.*))(.json)?[/#\\?]?$'
   const expected = '^(?:\\/(_next\\/data\\/[^\\/]{1,}))?(?:\\/([^\\/.]{1,}))\\/shows(?:\\/(.*))(.json)?[/#\\?]?$'
   const actual = parsePattern(regexPattern)

--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -192,15 +192,6 @@ test('netlify.toml-defined excludedPath are respected', () => {
   expect(declarations).toEqual(expectedDeclarations)
 })
 
-test('throws if there are lookaheads in a regex pattern', () => {
-  const regexPattern =
-    '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/((?!99|88).*))(.json)?[\\/#\\?]?$'
-
-  expect(() => {
-    parsePattern(regexPattern)
-  }).toThrow('Regular expressions with lookaheads are not supported')
-})
-
 test('Does not escape front slashes in a regex pattern if they are already escaped', () => {
   const regexPattern = '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
   const expected = '^(?:\\/(_next\\/data\\/[^\\/]{1,}))?(?:\\/([^\\/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'

--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -201,7 +201,7 @@ test('throws if there are lookaheads in a regex pattern', () => {
   }).toThrow('Regular expressions with lookaheads are not supported')
 })
 
-test('does not escape front slashes in a regex pattern if they are already escaped', () => {
+test('Does not escape front slashes in a regex pattern if they are already escaped', () => {
   const regexPattern = '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
   const expected = '^(?:\\/(_next\\/data\\/[^\\/]{1,}))?(?:\\/([^\\/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
   const actual = parsePattern(regexPattern)

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -131,7 +131,7 @@ const createDeclarationsFromFunctionConfigs = (
 // in Go, which is the engine used by our edge nodes.
 export const parsePattern = (pattern: string) => {
   // only escape front slashes if they haven't been escaped already
-  const normalizedPattern = pattern.replace(/(?<![\\[])\//g, '\\/')
+  const normalizedPattern = pattern.replace(/(?<!\\)\//g, '\\/')
 
   const regex = regexpAST.transform(`/${normalizedPattern}/`, {
     Assertion(path) {

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -130,8 +130,9 @@ const createDeclarationsFromFunctionConfigs = (
 // Validates and normalizes a pattern so that it's a valid regular expression
 // in Go, which is the engine used by our edge nodes.
 export const parsePattern = (pattern: string) => {
-  // Escaping forward slashes with back slashes.
-  const normalizedPattern = pattern.replace(/\//g, '\\/')
+  // only escape front slashes if they haven't been escaped already
+  const normalizedPattern = pattern.replace(/(?<![\\[])\//g, '\\/')
+
   const regex = regexpAST.transform(`/${normalizedPattern}/`, {
     Assertion(path) {
       // Lookaheads are not supported. If we find one, throw an error.

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -130,7 +130,7 @@ const createDeclarationsFromFunctionConfigs = (
 // Validates and normalizes a pattern so that it's a valid regular expression
 // in Go, which is the engine used by our edge nodes.
 export const parsePattern = (pattern: string) => {
-  // only escape front slashes if they haven't been escaped already
+  // Only escape front slashes if they haven't been escaped already.
   const normalizedPattern = pattern.replace(/(?<!\\)\//g, '\\/')
 
   const regex = regexpAST.transform(`/${normalizedPattern}/`, {


### PR DESCRIPTION
🎉 Thanks for sending this pull request! 🎉

Please make sure the title is clear and descriptive.

If you are fixing a typo or documentation, please skip these instructions.

Otherwise please fill in the sections below.

**Which problem is this pull request solving?**

Currently Next.js middleware breaks because the edge bundler modifies the regular expression matchers for URLs that Next.js generates.

**List other issues or pull requests related to this problem**

fixes #375 
fixes https://github.com/netlify/pod-ecosystem-frameworks/issues/414
relates to https://github.com/netlify/next-runtime/pull/1919

**Describe the solution you've chosen**

I've modified the regex to do a negative lookbehind to ensure we don't escape a front slash if it's already escaped.

**Describe alternatives you've considered**

N/A but as I mentioned in the issue, do we want the edge bundler modifying regex patterns?

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**

<img src="https://media2.giphy.com/media/kBNacfEgENH2Hon6hc/giphy.gif"/>