### PR TITLE
chore: add route matcher to tests

### DIFF
--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -243,4 +243,4 @@ const writeManifest = async ({ distDirectory, ...rest }: WriteManifestOptions) =
   return manifest
 }
 
-export { generateManifest, Manifest, writeManifest }
+export { generateManifest, Manifest, Route, writeManifest }


### PR DESCRIPTION
Adds a `getRouteMatcher` utility method to the tests, which lets us grab a manifest and test specific routes against it.

It also adds a specific test case that we were looking to understand the current support for.