### PR TITLE
fix: ensure regular expressions are properly escaped

### DIFF
--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -211,7 +211,7 @@ test('does not escape front slashes in a regex pattern if they are already escap
 
 test('escapes front slashes in a regex pattern', () => {
   const regexPattern = '^(?:/(_next/data/[^/]{1,}))?(?:/([^/.]{1,}))/shows(?:/(.*))(.json)?[/#\\?]?$'
-  const expected = '^(?:\\/(_next\\/data\\/[^\\/]{1,}))?(?:\\/([^\\/.]{1,}))\\/shows(?:\\/(.*))(.json)?[/#\\?]?$'
+  const expected = '^(?:\\/(_next\\/data\\/[^\\/]{1,}))?(?:\\/([^\\/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
   const actual = parsePattern(regexPattern)
 
   expect(actual).toEqual(expected)

--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -209,7 +209,7 @@ test('does not escape front slashes in a regex pattern if they are already escap
   expect(actual).toEqual(expected)
 })
 
-test('escapes front slashes in a regex pattern if they are not already escaped', () => {
+test('escapes front slashes in a regex pattern', () => {
   const regexPattern = '^(?:/(_next/data/[^/]{1,}))?(?:/([^/.]{1,}))/shows(?:/(.*))(.json)?[/#\\?]?$'
   const expected = '^(?:\\/(_next\\/data\\/[^\\/]{1,}))?(?:\\/([^\\/.]{1,}))\\/shows(?:\\/(.*))(.json)?[/#\\?]?$'
   const actual = parsePattern(regexPattern)

--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -203,7 +203,7 @@ test('throws if there are lookaheads in a regex pattern', () => {
 
 test('does not escape front slashes in a regex pattern if they are already escaped', () => {
   const regexPattern = '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
-  const expected = '^(?:\\/(_next\\/data\\/[^\\/]{1,}))?(?:\\/([^\\/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
+  const expected = '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
   const actual = parsePattern(regexPattern)
 
   expect(actual).toEqual(expected)
@@ -211,7 +211,7 @@ test('does not escape front slashes in a regex pattern if they are already escap
 
 test('escapes front slashes in a regex pattern', () => {
   const regexPattern = '^(?:/(_next/data/[^/]{1,}))?(?:/([^/.]{1,}))/shows(?:/(.*))(.json)?[/#\\?]?$'
-  const expected = '^(?:\\/(_next\\/data\\/[^\\/]{1,}))?(?:\\/([^\\/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
+  const expected = '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/(.*))(.json)?[/#\\?]?$'
   const actual = parsePattern(regexPattern)
 
   expect(actual).toEqual(expected)

--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -192,16 +192,7 @@ test('netlify.toml-defined excludedPath are respected', () => {
   expect(declarations).toEqual(expectedDeclarations)
 })
 
-test('throws if there are lookaheads in a regex pattern', () => {
-  const regexPattern =
-    '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/((?!99|88).*))(.json)?[\\/#\\?]?$'
-
-  expect(() => {
-    parsePattern(regexPattern)
-  }).toThrow('Regular expressions with lookaheads are not supported')
-})
-
-test('does not escape front slashes in a regex pattern if they are already escaped', () => {
+test('Does not escape front slashes in a regex pattern if they are already escaped', () => {
   const regexPattern = '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
   const expected = '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
   const actual = parsePattern(regexPattern)
@@ -209,7 +200,7 @@ test('does not escape front slashes in a regex pattern if they are already escap
   expect(actual).toEqual(expected)
 })
 
-test('escapes front slashes in a regex pattern', () => {
+test('Escapes front slashes in a regex pattern', () => {
   const regexPattern = '^(?:/(_next/data/[^/]{1,}))?(?:/([^/.]{1,}))/shows(?:/(.*))(.json)?[/#\\?]?$'
   const expected = '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/(.*))(.json)?[/#\\?]?$'
   const actual = parsePattern(regexPattern)

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -131,7 +131,7 @@ const createDeclarationsFromFunctionConfigs = (
 // in Go, which is the engine used by our edge nodes.
 export const parsePattern = (pattern: string) => {
   // only escape front slashes if they haven't been escaped already
-  const normalizedPattern = pattern.replace(/(?<![\\[])\//g, '\\/')
+  const normalizedPattern = pattern.replace(/(?<!\\)\//g, '\\/')
 
   const regex = regexpAST.transform(`/${normalizedPattern}/`, {
     Assertion(path) {

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -130,8 +130,9 @@ const createDeclarationsFromFunctionConfigs = (
 // Validates and normalizes a pattern so that it's a valid regular expression
 // in Go, which is the engine used by our edge nodes.
 export const parsePattern = (pattern: string) => {
-  // Escaping forward slashes with back slashes.
-  const normalizedPattern = pattern.replace(/\//g, '\\/')
+  // only escape front slashes if they haven't been escaped already
+  const normalizedPattern = pattern.replace(/(?<![\\[])\//g, '\\/')
+
   const regex = regexpAST.transform(`/${normalizedPattern}/`, {
     Assertion(path) {
       // Lookaheads are not supported. If we find one, throw an error.

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -130,10 +130,8 @@ const createDeclarationsFromFunctionConfigs = (
 // Validates and normalizes a pattern so that it's a valid regular expression
 // in Go, which is the engine used by our edge nodes.
 export const parsePattern = (pattern: string) => {
-  // only escape front slashes if they haven't been escaped already
-  const normalizedPattern = pattern.replace(/(?<!\\)\//g, '\\/')
-
-  const regex = regexpAST.transform(`/${normalizedPattern}/`, {
+  const regexp = new RegExp(pattern)
+  const newRegexp = regexpAST.transform(regexp, {
     Assertion(path) {
       // Lookaheads are not supported. If we find one, throw an error.
       if (path.node.kind === 'Lookahead') {
@@ -156,5 +154,5 @@ export const parsePattern = (pattern: string) => {
   })
 
   // Strip leading and forward slashes.
-  return regex.toString().slice(1, -1)
+  return newRegexp.toString().slice(1, -1)
 }


### PR DESCRIPTION
Runs the regular expressions through the `RegExp` constructor to ensure that they are properly escaped, rather than handling the escaping ourselves.

Supersedes #376.