### PR TITLE
feat: support `node:` prefix

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # Should match the `DENO_VERSION_RANGE` constant in `node/bridge.ts`.
-          deno-version: v1.22.0
+          deno-version: v1.30.0
       - name: Install dependencies
         run: npm ci
       - name: Tests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,7 +27,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # Should match the `DENO_VERSION_RANGE` constant in `node/bridge.ts`.
-          deno-version: v1.22.0
+          deno-version: v1.30.0
       - name: Setup Deno dependencies
         run: deno cache https://deno.land/x/eszip@v0.40.0/eszip.ts
       - name: Node.js ${{ matrix.node-version }}

--- a/deno/lib/stage2.ts
+++ b/deno/lib/stage2.ts
@@ -75,7 +75,7 @@ const stage2Loader = (basePath: string, functions: InputFunction[], externals: S
       return inlineModule(specifier, importMapData)
     }
 
-    if (specifier === PUBLIC_SPECIFIER || externals.has(specifier)) {
+    if (specifier === PUBLIC_SPECIFIER || externals.has(specifier) || specifier.startsWith('node:')) {
       return {
         kind: 'external',
         specifier,

--- a/node/bridge.ts
+++ b/node/bridge.ts
@@ -12,7 +12,7 @@ import { getLogger, Logger } from './logger.js'
 import { getBinaryExtension } from './platform.js'
 
 const DENO_VERSION_FILE = 'version.txt'
-const DENO_VERSION_RANGE = '^1.22.0'
+const DENO_VERSION_RANGE = '^1.30.0'
 
 type OnBeforeDownloadHook = () => void | Promise<void>
 type OnAfterDownloadHook = (error?: Error) => void | Promise<void>

--- a/test/fixtures/imports_node_specifier/netlify/edge-functions/func1.ts
+++ b/test/fixtures/imports_node_specifier/netlify/edge-functions/func1.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert'
+import process from 'node:process'
+
+export default () => {
+  Deno.env.set('NETLIFY_TEST', '12345')
+  assert.deepEqual(process.env.NETLIFY_TEST, '12345')
+
+  return new Response('ok')
+}
+
+export const config = {
+  path: '/func1',
+}


### PR DESCRIPTION
**Which problem is this pull request solving?**

Adds support for Node built-ins via specifiers with the `node:` prefix. It works by marking those specifiers as externals, which lets Deno handle them internally.

https://deno.com/blog/node-builtins-on-deploy