### PR TITLE
fix: update minimum version of semver to be ESM compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "p-wait-for": "^4.1.0",
         "path-key": "^4.0.0",
         "regexp-tree": "^0.1.24",
-        "semver": "^7.3.5",
+        "semver": "^7.3.8",
         "tmp-promise": "^3.0.3",
         "uuid": "^9.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "p-wait-for": "^4.1.0",
     "path-key": "^4.0.0",
     "regexp-tree": "^0.1.24",
-    "semver": "^7.3.5",
+    "semver": "^7.3.8",
     "tmp-promise": "^3.0.3",
     "uuid": "^9.0.0"
   }


### PR DESCRIPTION
Ref netlify/cli#5749

with version 7.3.7 this happens, so we need at least 7.3.8: 

<img width="2054" alt="Screenshot 2023-06-05 at 14 18 08" src="https://github.com/netlify/zip-it-and-ship-it/assets/231804/8cd3e8f8-8564-4cde-8f45-e2d8f54ad61d">
