### PR TITLE
fix: improvements to download process of deno

### DIFF
--- a/node/bridge.ts
+++ b/node/bridge.ts
@@ -12,6 +12,8 @@ import { getLogger, Logger } from './logger.js'
 import { getBinaryExtension } from './platform.js'
 
 const DENO_VERSION_FILE = 'version.txt'
+// When updating DENO_VERSION_RANGE, ensure that the deno version installed in the
+// build-image/buildbot does satisfy this range!
 const DENO_VERSION_RANGE = '^1.30.0'
 
 type OnBeforeDownloadHook = () => void | Promise<void>

--- a/node/bridge.ts
+++ b/node/bridge.ts
@@ -106,7 +106,9 @@ class DenoBridge {
       }
 
       return version[1]
-    } catch {}
+    } catch (error) {
+      this.logger.system('getBinaryVersion failed', error)
+    }
   }
 
   private async getCachedBinary() {

--- a/node/downloader.ts
+++ b/node/downloader.ts
@@ -27,9 +27,9 @@ const download = async (targetDirectory: string, versionRange: string) => {
 
   try {
     await new Promise((resolve, reject) => {
-      data.pipe(file)
       data.on('error', reject)
       file.on('finish', resolve)
+      data.pipe(file)
     })
 
     await extractBinaryFromZip(zipPath, binaryPath, binaryName)


### PR DESCRIPTION
- A small note about the deno version.
- Add even handlers before calling `pipe()`
- log errors to system log when `getBinaryVersion` fails