### PR TITLE
fix: parseConfig stumbling over `globalThis.Netlify` usage in global scope

### DIFF
--- a/deno/config.ts
+++ b/deno/config.ts
@@ -1,6 +1,9 @@
 const [functionURL, collectorURL, rawExitCodes] = Deno.args
 const exitCodes = JSON.parse(rawExitCodes)
 
+// TODO: naïve, should this be imported from https://edge.netlify.com/bootstrap/globals.ts instead?
+globalThis.Netlify = { env: Deno.env }
+
 let func
 
 try {

--- a/deno/config.ts
+++ b/deno/config.ts
@@ -1,8 +1,8 @@
 const [functionURL, collectorURL, bootstrapURL, rawExitCodes] = Deno.args
 const exitCodes = JSON.parse(rawExitCodes)
 
-const { env } = await import(new URL('./globals.ts', bootstrapURL).toString())
-globalThis.Netlify = { env }
+const { Netlify } = await import(bootstrapURL)
+globalThis.Netlify = Netlify
 
 let func
 

--- a/deno/config.ts
+++ b/deno/config.ts
@@ -1,8 +1,8 @@
-const [functionURL, collectorURL, rawExitCodes] = Deno.args
+const [functionURL, collectorURL, bootstrapURL, rawExitCodes] = Deno.args
 const exitCodes = JSON.parse(rawExitCodes)
 
-// TODO: naïve, should this be imported from https://edge.netlify.com/bootstrap/globals.ts instead?
-globalThis.Netlify = { env: Deno.env }
+const { env } = await import(new URL('./globals.ts', bootstrapURL).toString())
+globalThis.Netlify = { env }
 
 let func
 

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -110,14 +110,17 @@ const bundle = async (
   // rename the bundles to their permanent names.
   await createFinalBundles([functionBundle], distDirectory, buildID)
 
+  // TODO: we should probably inject this?
+  const bootstrapURL = 'https://edge.netlify.com/bootstrap/index-combined.ts'
+
   // Retrieving a configuration object for each function.
   // Run `getFunctionConfig` in parallel as it is a non-trivial operation and spins up deno
   const internalConfigPromises = internalFunctions.map(
-    async (func) => [func.name, await getFunctionConfig(func, importMap, deno, logger)] as const,
+    async (func) => [func.name, await getFunctionConfig({ func, importMap, deno, log: logger, bootstrapURL })] as const,
   )
 
   const userConfigPromises = userFunctions.map(
-    async (func) => [func.name, await getFunctionConfig(func, importMap, deno, logger)] as const,
+    async (func) => [func.name, await getFunctionConfig({ func, importMap, deno, log: logger, bootstrapURL })] as const,
   )
 
   // Creating a hash of function names to configuration objects.

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -31,6 +31,7 @@ interface BundleOptions {
   onBeforeDownload?: OnBeforeDownloadHook
   systemLogger?: LogFunction
   internalSrcFolder?: string
+  bootstrapURL?: string
 }
 
 const bundle = async (
@@ -49,6 +50,7 @@ const bundle = async (
     onBeforeDownload,
     systemLogger,
     internalSrcFolder,
+    bootstrapURL = 'https://edge.netlify.com/bootstrap/index-combined.ts',
   }: BundleOptions = {},
 ) => {
   const logger = getLogger(systemLogger, debug)
@@ -109,9 +111,6 @@ const bundle = async (
   // which we can only compute now that the files have been generated. So let's
   // rename the bundles to their permanent names.
   await createFinalBundles([functionBundle], distDirectory, buildID)
-
-  // TODO: we should probably inject this?
-  const bootstrapURL = 'https://edge.netlify.com/bootstrap/index-combined.ts'
 
   // Retrieving a configuration object for each function.
   // Run `getFunctionConfig` in parallel as it is a non-trivial operation and spins up deno

--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -14,6 +14,8 @@ import { FunctionConfig, getFunctionConfig } from './config.js'
 import type { Declaration } from './declaration.js'
 import { ImportMap } from './import_map.js'
 
+const bootstrapURL = 'https://edge.netlify.com/bootstrap/index-combined.ts'
+
 const importMapFile = {
   baseURL: new URL('file:///some/path/import-map.json'),
   imports: {
@@ -136,15 +138,16 @@ describe('`getFunctionConfig` extracts configuration properties from function fi
     await fs.writeFile(path, func.source)
 
     const funcCall = () =>
-      getFunctionConfig(
-        {
+      getFunctionConfig({
+        func: {
           name: func.name,
           path,
         },
-        new ImportMap([importMapFile]),
+        importMap: new ImportMap([importMapFile]),
         deno,
-        logger,
-      )
+        log: logger,
+        bootstrapURL,
+      })
 
     if (func.error) {
       await expect(funcCall()).rejects.toThrowError(func.error)
@@ -234,15 +237,16 @@ test('Passes validation if default export exists and is a function', async () =>
   await fs.writeFile(path, func.source)
 
   await expect(
-    getFunctionConfig(
-      {
+    getFunctionConfig({
+      func: {
         name: func.name,
         path,
       },
-      new ImportMap([importMapFile]),
+      importMap: new ImportMap([importMapFile]),
       deno,
-      logger,
-    ),
+      log: logger,
+      bootstrapURL,
+    }),
   ).resolves.not.toThrow()
 
   await rm(tmpDir, { force: true, recursive: true, maxRetries: 10 })
@@ -270,15 +274,16 @@ test('Fails validation if default export is not function', async () => {
 
   await fs.writeFile(path, func.source)
 
-  const config = getFunctionConfig(
-    {
+  const config = getFunctionConfig({
+    func: {
       name: func.name,
       path,
     },
-    new ImportMap([importMapFile]),
+    importMap: new ImportMap([importMapFile]),
     deno,
-    logger,
-  )
+    log: logger,
+    bootstrapURL,
+  })
 
   await expect(config).rejects.toThrowError(invalidDefaultExportErr(path))
 
@@ -306,15 +311,16 @@ test('Fails validation if default export is not present', async () => {
 
   await fs.writeFile(path, func.source)
 
-  const config = getFunctionConfig(
-    {
+  const config = getFunctionConfig({
+    func: {
       name: func.name,
       path,
     },
-    new ImportMap([importMapFile]),
+    importMap: new ImportMap([importMapFile]),
     deno,
-    logger,
-  )
+    log: logger,
+    bootstrapURL,
+  })
 
   await expect(config).rejects.toThrowError(invalidDefaultExportErr(path))
 

--- a/node/config.ts
+++ b/node/config.ts
@@ -52,7 +52,19 @@ const getConfigExtractor = () => {
   return configExtractorPath
 }
 
-export const getFunctionConfig = async (func: EdgeFunction, importMap: ImportMap, deno: DenoBridge, log: Logger) => {
+export const getFunctionConfig = async ({
+  func,
+  importMap,
+  deno,
+  bootstrapURL,
+  log,
+}: {
+  func: EdgeFunction
+  importMap: ImportMap
+  deno: DenoBridge
+  bootstrapURL: string
+  log: Logger
+}) => {
   // The extractor is a Deno script that will import the function and run its
   // `config` export, if one exists.
   const extractorPath = getConfigExtractor()
@@ -79,6 +91,7 @@ export const getFunctionConfig = async (func: EdgeFunction, importMap: ImportMap
       extractorPath,
       pathToFileURL(func.path).href,
       pathToFileURL(collector.path).href,
+      bootstrapURL,
       JSON.stringify(ConfigExitCode),
     ],
     { rejectOnExitCode: false },

--- a/node/server/server.test.ts
+++ b/node/server/server.test.ts
@@ -31,6 +31,10 @@ test('Starts a server and serves requests for edge functions', async () => {
       name: 'greet',
       path: join(paths.internal, 'greet.ts'),
     },
+    {
+      name: 'global_netlify',
+      path: join(paths.user, 'global_netlify.ts'),
+    },
   ]
   const options = {
     getFunctionsConfig: true,
@@ -44,7 +48,7 @@ test('Starts a server and serves requests for edge functions', async () => {
     options,
   )
   expect(success).toBe(true)
-  expect(functionsConfig).toEqual([{ path: '/my-function' }, {}])
+  expect(functionsConfig).toEqual([{ path: '/my-function' }, {}, { path: '/global-netlify' }])
 
   for (const key in functions) {
     const graphEntry = graph?.modules.some(
@@ -74,4 +78,16 @@ test('Starts a server and serves requests for edge functions', async () => {
   })
   expect(response2.status).toBe(200)
   expect(await response2.text()).toBe('HELLO!')
+
+  const response3 = await fetch(`http://0.0.0.0:${port}/global-netlify`, {
+    headers: {
+      'x-nf-edge-functions': 'global_netlify',
+      'x-ef-passthrough': 'passthrough',
+      'X-NF-Request-ID': uuidv4(),
+    },
+  })
+  expect(await response3.json()).toEqual({
+    global: 'i love netlify',
+    local: 'i love netlify',
+  })
 })

--- a/node/server/server.ts
+++ b/node/server/server.ts
@@ -87,7 +87,9 @@ const prepareServer = ({
     let functionsConfig: FunctionConfig[] = []
 
     if (options.getFunctionsConfig) {
-      functionsConfig = await Promise.all(functions.map((func) => getFunctionConfig(func, importMap, deno, logger)))
+      functionsConfig = await Promise.all(
+        functions.map((func) => getFunctionConfig({ func, importMap, deno, bootstrapURL, log: logger })),
+      )
     }
 
     const success = await waitForServer(port, processRef.ps)

--- a/test/fixtures/serve_test/netlify/edge-functions/global_netlify.ts
+++ b/test/fixtures/serve_test/netlify/edge-functions/global_netlify.ts
@@ -1,0 +1,14 @@
+import { Config } from 'https://edge.netlify.com/'
+
+const global = globalThis.Netlify.env.get('very_secret_secret')
+
+export default () => {
+  return Response.json({
+    global,
+    local: globalThis.Netlify.env.get('very_secret_secret'),
+  })
+}
+
+export const config: Config = {
+  path: '/global-netlify',
+}


### PR DESCRIPTION
When a function accesses `globalThis.Netlify`, the scanning for function config currently fails because it's not defining `globalThis.Netlify`.

This PR fixes that.