### PR TITLE
feat: support `path` array in `netlify.toml`

### DIFF
--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -41,8 +41,7 @@ test('In-source config takes precedence over netlify.toml config', () => {
   } as Record<string, FunctionConfig>
 
   const expectedDeclarations = [
-    { function: 'geolocation', path: '/geo-isc', cache: 'manual' },
-    { function: 'geolocation', path: '/*', cache: 'manual' },
+    { function: 'geolocation', path: ['/geo-isc', '/*'], cache: 'manual' },
     { function: 'json', path: '/json', cache: 'off' },
   ]
 
@@ -63,7 +62,7 @@ test("Declarations don't break if no in-source config is provided", () => {
   } as Record<string, FunctionConfig>
 
   const expectedDeclarations = [
-    { function: 'geolocation', path: '/geo-isc', cache: 'manual' },
+    { function: 'geolocation', path: ['/geo-isc'], cache: 'manual' },
     { function: 'json', path: '/json', cache: 'manual' },
   ]
 

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -12,12 +12,12 @@ interface BaseDeclaration {
 }
 
 type DeclarationWithPath = BaseDeclaration & {
-  path: Path
+  path: Path | Path[]
   excludedPath?: Path | Path[]
 }
 
 type DeclarationWithPattern = BaseDeclaration & {
-  pattern: string
+  pattern: string | string[]
   excludedPattern?: string | string[]
 }
 
@@ -66,13 +66,7 @@ const getDeclarationsFromInput = (
       // If no config is found, add the declaration as is.
       declarations.push(declaration)
     } else if (config.path?.length) {
-      // If we have a path specified as either a string or non-empty array,
-      // create a declaration for each path.
-      const paths = Array.isArray(config.path) ? config.path : [config.path]
-
-      paths.forEach((path) => {
-        declarations.push({ ...declaration, cache: config.cache, path })
-      })
+      declarations.push({ ...declaration, cache: config.cache, path: config.path })
     } else {
       // With an in-source config without a path, add the config to the declaration.
       const { path, excludedPath, ...rest } = config

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -397,12 +397,20 @@ test('Converts named capture groups to unnamed capture groups in regular express
 })
 
 test('TOML declarations can contain multiple paths', () => {
-  const functions = [{ name: 'func-1', path: '/path/to/func-1.ts' }]
-  const declarations: Declaration[] = [{ function: 'func-1', path: ['/f1/*', '/f1.1/*'], excludedPath: '/f1/exclude' }]
+  const functions = [
+    { name: 'func-1', path: '/path/to/func-1.ts' },
+    { name: 'func-2', path: '/path/to/func-2.ts' },
+  ]
+  const declarations: Declaration[] = [
+    { function: 'func-1', path: ['/f1/*', '/f1.1/*'], excludedPath: '/f1/exclude' },
+    { function: 'func-2', pattern: ['^/f2/?$', '^/f2-2/?$'], excludedPattern: '^/f2/excluded/?$' },
+  ]
   const manifest = generateManifest({ bundles: [], declarations, functions })
   const expectedRoutes = [
     { function: 'func-1', pattern: '^/f1/.*/?$', excluded_patterns: ['^/f1/exclude/?$'] },
     { function: 'func-1', pattern: '^/f1\\.1/.*/?$', excluded_patterns: ['^/f1/exclude/?$'] },
+    { function: 'func-2', pattern: '^/f2/?$', excluded_patterns: ['^/f2/excluded/?$'] },
+    { function: 'func-2', pattern: '^/f2-2/?$', excluded_patterns: ['^/f2/excluded/?$'] },
   ]
 
   expect(manifest.routes).toEqual(expectedRoutes)

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -395,3 +395,15 @@ test('Converts named capture groups to unnamed capture groups in regular express
 
   expect(manifest.routes).toEqual([{ function: 'func-1', pattern: '^/(\\w+)$', excluded_patterns: [] }])
 })
+
+test('TOML declarations can contain multiple paths', () => {
+  const functions = [{ name: 'func-1', path: '/path/to/func-1.ts' }]
+  const declarations: Declaration[] = [{ function: 'func-1', path: ['/f1/*', '/f1.1/*'], excludedPath: '/f1/exclude' }]
+  const manifest = generateManifest({ bundles: [], declarations, functions })
+  const expectedRoutes = [
+    { function: 'func-1', pattern: '^/f1/.*/?$', excluded_patterns: ['^/f1/exclude/?$'] },
+    { function: 'func-1', pattern: '^/f1\\.1/.*/?$', excluded_patterns: ['^/f1/exclude/?$'] },
+  ]
+
+  expect(manifest.routes).toEqual(expectedRoutes)
+})


### PR DESCRIPTION
Part of https://github.com/netlify/pod-dev-foundations/issues/565.

We're documenting support for this, but it's not working. This PR adds support for mutliple paths in a single declaration.