### PR TITLE
feat!: correctly interpret `/**/*` paths

### DIFF
--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -198,7 +198,7 @@ test('Loads function paths from the in-source `config` function', async () => {
   expect(routes[2]).toEqual({ function: 'framework-func1', pattern: '^/framework-func1/?$', excluded_patterns: [] })
   expect(routes[3]).toEqual({ function: 'user-func1', pattern: '^/user-func1/?$', excluded_patterns: [] })
   expect(routes[4]).toEqual({ function: 'user-func3', pattern: '^/user-func3/?$', excluded_patterns: [] })
-  expect(routes[5]).toEqual({ function: 'user-func5', pattern: '^/user-func5/.*/?$', excluded_patterns: [] })
+  expect(routes[5]).toEqual({ function: 'user-func5', pattern: '^/user-func5/([^/]*)/?$', excluded_patterns: [] })
 
   expect(postCacheRoutes.length).toBe(1)
   expect(postCacheRoutes[0]).toEqual({ function: 'user-func4', pattern: '^/user-func4/?$', excluded_patterns: [] })

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -179,7 +179,7 @@ test('excludedPath from ISC goes into function_config, TOML goes into routes', (
   ]
   const userFunctionConfig: Record<string, FunctionConfig> = {
     customisation: {
-      excludedPath: ['/*.css', '/*.jpg'],
+      excludedPath: ['/**/*.css', '/**/*.jpg'],
     },
   }
   const internalFunctionConfig: Record<string, FunctionConfig> = {}
@@ -204,7 +204,7 @@ test('excludedPath from ISC goes into function_config, TOML goes into routes', (
   ])
   expect(manifest.function_config).toEqual({
     customisation: {
-      excluded_patterns: ['^/([^/]*)\\.css/?$', '^/([^/]*)\\.jpg/?$'],
+      excluded_patterns: ['^/((?:[^/]*(?:/|$))*)([^/]*)\\.css/?$', '^/((?:[^/]*(?:/|$))*)([^/]*)\\.jpg/?$'],
     },
   })
 

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -46,7 +46,7 @@ test('Generates a manifest with display names', () => {
   }
   const manifest = generateManifest({ bundles: [], declarations, functions, internalFunctionConfig })
 
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/.*/?$', excluded_patterns: [] }]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/([^/]*)/?$', excluded_patterns: [] }]
   expect(manifest.function_config).toEqual({
     'func-1': { name: 'Display Name' },
   })
@@ -65,7 +65,7 @@ test('Generates a manifest with a generator field', () => {
   }
   const manifest = generateManifest({ bundles: [], declarations, functions, internalFunctionConfig })
 
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/.*/?$', excluded_patterns: [] }]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/([^/]*)/?$', excluded_patterns: [] }]
   const expectedFunctionConfig = { 'func-1': { generator: '@netlify/fake-plugin@1.0.0' } }
   expect(manifest.routes).toEqual(expectedRoutes)
   expect(manifest.function_config).toEqual(expectedFunctionConfig)
@@ -84,9 +84,9 @@ test('Generates a manifest with excluded paths and patterns', () => {
   ]
   const manifest = generateManifest({ bundles: [], declarations, functions })
   const expectedRoutes = [
-    { function: 'func-1', pattern: '^/f1/.*/?$', excluded_patterns: ['^/f1/exclude/?$'] },
+    { function: 'func-1', pattern: '^/f1/([^/]*)/?$', excluded_patterns: ['^/f1/exclude/?$'] },
     { function: 'func-2', pattern: '^/f2/.*/?$', excluded_patterns: ['^/f2/exclude$', '^/f2/exclude-as-well$'] },
-    { function: 'func-3', pattern: '^/.*/?$', excluded_patterns: ['^/.*/.*\\.html/?$'] },
+    { function: 'func-3', pattern: '^/([^/]*)/?$', excluded_patterns: ['^/((?:[^/]*(?:/|$))*)([^/]*)\\.html/?$'] },
   ]
 
   expect(manifest.routes).toEqual(expectedRoutes)
@@ -111,7 +111,7 @@ test('TOML-defined paths can be combined with ISC-defined excluded paths', () =>
   }
   const manifest = generateManifest({ bundles: [], declarations, functions, userFunctionConfig })
 
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/.*/?$', excluded_patterns: [] }]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/([^/]*)/?$', excluded_patterns: [] }]
 
   expect(manifest.routes).toEqual(expectedRoutes)
   expect(manifest.function_config).toEqual({
@@ -193,18 +193,18 @@ test('excludedPath from ISC goes into function_config, TOML goes into routes', (
   expect(manifest.routes).toEqual([
     {
       function: 'customisation',
-      pattern: '^/showcases/.*/?$',
+      pattern: '^/showcases/([^/]*)/?$',
       excluded_patterns: [],
     },
     {
       function: 'customisation',
-      pattern: '^/checkout/.*/?$',
-      excluded_patterns: ['^/.*/terms-and-conditions/?$'],
+      pattern: '^/checkout/([^/]*)/?$',
+      excluded_patterns: ['^/([^/]*)/terms-and-conditions/?$'],
     },
   ])
   expect(manifest.function_config).toEqual({
     customisation: {
-      excluded_patterns: ['^/.*\\.css/?$', '^/.*\\.jpg/?$'],
+      excluded_patterns: ['^/([^/]*)\\.css/?$', '^/([^/]*)\\.jpg/?$'],
     },
   })
 
@@ -334,8 +334,8 @@ test('Generates a manifest with layers', () => {
     { function: 'func-2', path: '/f2/*' },
   ]
   const expectedRoutes = [
-    { function: 'func-1', pattern: '^/f1/.*/?$', excluded_patterns: [] },
-    { function: 'func-2', pattern: '^/f2/.*/?$', excluded_patterns: [] },
+    { function: 'func-1', pattern: '^/f1/([^/]*)/?$', excluded_patterns: [] },
+    { function: 'func-2', pattern: '^/f2/([^/]*)/?$', excluded_patterns: [] },
   ]
   const layers = [
     {

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -97,6 +97,10 @@ test('Generates a manifest with excluded paths and patterns', () => {
 
   expect(matcher('/f1/hello')?.function).toBe('func-1')
   expect(matcher('/grandparent/parent/child/grandchild.html')?.function).toBeUndefined()
+
+  expect(matcher('/test.jpg')?.function).toBe('func-3')
+  expect(matcher('/test.html')?.function).toBeUndefined()
+  expect(matcher('/sub/test.html')?.function).toBeUndefined()
 })
 
 test('TOML-defined paths can be combined with ISC-defined excluded paths', () => {

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -167,7 +167,7 @@ const generateManifest = ({
 const pathToRegularExpression = (path: string) => {
   // We use the global flag so that `globToRegExp` will not wrap the expression
   // with `^` and `$`. We'll do that ourselves.
-  const regularExpression = globToRegExp(path, { flags: 'g' })
+  const regularExpression = globToRegExp(path, { flags: 'g', globstar: true })
 
   // Wrapping the expression source with `^` and `$`. Also, adding an optional
   // trailing slash, so that a declaration of `path: "/foo"` matches requests


### PR DESCRIPTION
This came up over in this forums post: https://answers.netlify.com/t/please-clarify-documentation-for-edge-functions-excludedpath/97443

Given the path `/**/*.html`, i'd expect it to match both `/foo.html` and `/sub/foo.html`. With our current handling, only `/sub/foo.html` is matched however - i've demonstrated this in a test added in the first commit of this PR.

After reading into this, it turns out that the special meaning of `**` [was introduced "recently" in 2010](https://www.linuxjournal.com/content/globstar-new-bash-globbing-option) and is called `globstar`. We don't have it enabled for edge functions currently, which means that `/**/*.html` is equivalent to `/*/*.html`. This probably comes at a surprise to our customers.

This PR enables the globstar option. This is a breaking change to what we implemented, and i'm unsure what's the best way of rolling this out. Here's a matrix for how it'd change behaviour:

|  | matched paths, currently  | with `globstar` |
|- |-| -|
| `/*.html` | `/foo.html`, `/sub/foo.html` | `/foo.html` |
| `/**/*.html` | `/sub/foo.html` | `/foo.html`, `/sub/foo.html`|

This would essentially break sites that have an edge function at `/*`, so i'm really unsure if this is a change we can make now 🤔  Let's have a discussion on that.