### PR TITLE
fix: ensure patterns match on whole path

### DIFF
--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -175,3 +175,11 @@ test('Escapes front slashes in a regex pattern', () => {
 
   expect(actual).toEqual(expected)
 })
+
+test('Ensures pattern match on the whole path', () => {
+  const regexPattern = '/foo/.*/bar'
+  const expected = '^\\/foo\\/.*\\/bar$'
+  const actual = parsePattern(regexPattern)
+
+  expect(actual).toEqual(expected)
+})

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -115,7 +115,11 @@ const createDeclarationsFromFunctionConfigs = (
 // Validates and normalizes a pattern so that it's a valid regular expression
 // in Go, which is the engine used by our edge nodes.
 export const parsePattern = (pattern: string) => {
-  const regexp = new RegExp(pattern)
+  let enclosedPattern = pattern
+  if (!pattern.startsWith('^')) enclosedPattern = `^${enclosedPattern}`
+  if (!pattern.endsWith('$')) enclosedPattern = `${enclosedPattern}$`
+
+  const regexp = new RegExp(enclosedPattern)
   const newRegexp = regexpAST.transform(regexp, {
     Assertion(path) {
       // Lookaheads are not supported. If we find one, throw an error.


### PR DESCRIPTION
Through https://netlify.slack.com/archives/C0183KVDHFH/p1690359798528619?thread_ts=1690283461.628349&cid=C0183KVDHFH, we discovered that we don't document that regex patterns need to be enclosed in `^...$`. But we validate on it:

https://github.com/netlify/edge-bundler/blob/db1f51edb7f312022910ae3f13d0e6b9a9d21f30/node/validation/manifest/index.ts#L19-L24

We could either add this requirement to our documentation, or automatically enclose patterns that don't have the `^...$`. I believe the latter is better DX. This PR implements that.