### PR TITLE
feat: transpile negative lookaheads into exclusions

### DIFF
--- a/node/declaration.test.ts
+++ b/node/declaration.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from 'vitest'
 
+import { getRouteMatcher } from '../test/util.js'
+
 import { FunctionConfig } from './config.js'
 import { Declaration, mergeDeclarations, parsePattern } from './declaration.js'
 
@@ -163,23 +165,43 @@ test('netlify.toml-defined excludedPath are respected', () => {
 test('Does not escape front slashes in a regex pattern if they are already escaped', () => {
   const regexPattern = '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
   const expected = '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/(.*))(.json)?[\\/#\\?]?$'
-  const actual = parsePattern(regexPattern)
 
-  expect(actual).toEqual(expected)
+  expect(parsePattern(regexPattern)).toEqual({
+    pattern: expected,
+    excludedPatterns: [],
+  })
 })
 
 test('Escapes front slashes in a regex pattern', () => {
   const regexPattern = '^(?:/(_next/data/[^/]{1,}))?(?:/([^/.]{1,}))/shows(?:/(.*))(.json)?[/#\\?]?$'
   const expected = '^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/([^/.]{1,}))\\/shows(?:\\/(.*))(.json)?[/#\\?]?$'
-  const actual = parsePattern(regexPattern)
 
-  expect(actual).toEqual(expected)
+  expect(parsePattern(regexPattern)).toEqual({
+    pattern: expected,
+    excludedPatterns: [],
+  })
 })
 
 test('Ensures pattern match on the whole path', () => {
   const regexPattern = '/foo/.*/bar'
   const expected = '^\\/foo\\/.*\\/bar$'
-  const actual = parsePattern(regexPattern)
 
-  expect(actual).toEqual(expected)
+  expect(parsePattern(regexPattern)).toEqual({
+    pattern: expected,
+    excludedPatterns: [],
+  })
+})
+
+test('Transforms negative lookaheads into two patterns', () => {
+  const { pattern, excludedPatterns } = parsePattern('/((?!_next/static).*)')
+  expect(pattern).toEqual('^\\/(.*)$')
+  expect(excludedPatterns).toEqual(['^\\/((?:_next\\/static).*)$'])
+
+  const matcher = getRouteMatcher({
+    routes: [{ pattern, excluded_patterns: excludedPatterns, function: 'foo' }],
+    function_config: {},
+  })
+
+  expect(matcher('/hello')).toBeTruthy()
+  expect(matcher('/_next/static/hello')).toBeFalsy()
 })

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -131,13 +131,13 @@ const generateManifest = ({
       return
     }
 
-    const pattern = getRegularExpression(declaration, featureFlags)
+    const { pattern, negativeLookaheadExclusions } = getRegularExpression(declaration, featureFlags)
     const excludedPattern = getExcludedRegularExpressions(declaration, featureFlags)
 
     const route: Route = {
       function: func.name,
       pattern: serializePattern(pattern),
-      excluded_patterns: excludedPattern.map(serializePattern),
+      excluded_patterns: [...excludedPattern, ...negativeLookaheadExclusions].map(serializePattern),
     }
 
     if (declaration.cache === Cache.Manual) {
@@ -191,7 +191,10 @@ const pathToRegularExpression = (path: string, featureFlags?: FeatureFlags) => {
   return normalizedSource
 }
 
-const getRegularExpression = (declaration: Declaration, featureFlags?: FeatureFlags): string => {
+const getRegularExpression = (
+  declaration: Declaration,
+  featureFlags?: FeatureFlags,
+): { pattern: string; negativeLookaheadExclusions: string[] } => {
   if ('pattern' in declaration) {
     try {
       return parsePattern(declaration.pattern)
@@ -213,7 +216,7 @@ const getRegularExpression = (declaration: Declaration, featureFlags?: FeatureFl
     }
   }
 
-  return pathToRegularExpression(declaration.path, featureFlags)
+  return { pattern: pathToRegularExpression(declaration.path, featureFlags), negativeLookaheadExclusions: [] }
 }
 
 const getExcludedRegularExpressions = (declaration: Declaration, featureFlags?: FeatureFlags): string[] => {


### PR DESCRIPTION
Next.js encourages the use of negative lookahead expressions, which Golang's flavour of regex doesn't support due to unpredictable runtime performance. This PR is an attempt at transpiling negative lookaheads into `excluded_patterns`. It's not much more than a rough idea, and likely doesn't work at all, so scrutiny is more than welcome!