### PR TITLE
feat: add `path` to manifest

### DIFF
--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -197,15 +197,50 @@ test('Loads function paths from the in-source `config` function', async () => {
   expect(generatedFiles.includes(bundles[0].asset)).toBe(true)
 
   expect(routes.length).toBe(6)
-  expect(routes[0]).toEqual({ function: 'framework-func2', pattern: '^/framework-func2/?$', excluded_patterns: [] })
-  expect(routes[1]).toEqual({ function: 'user-func2', pattern: '^/user-func2/?$', excluded_patterns: [] })
-  expect(routes[2]).toEqual({ function: 'framework-func1', pattern: '^/framework-func1/?$', excluded_patterns: [] })
-  expect(routes[3]).toEqual({ function: 'user-func1', pattern: '^/user-func1/?$', excluded_patterns: [] })
-  expect(routes[4]).toEqual({ function: 'user-func3', pattern: '^/user-func3/?$', excluded_patterns: [] })
-  expect(routes[5]).toEqual({ function: 'user-func5', pattern: '^/user-func5(?:/(.*))/?$', excluded_patterns: [] })
+  expect(routes[0]).toEqual({
+    function: 'framework-func2',
+    pattern: '^/framework-func2/?$',
+    excluded_patterns: [],
+    raw_pattern: '/framework-func2',
+  })
+  expect(routes[1]).toEqual({
+    function: 'user-func2',
+    pattern: '^/user-func2/?$',
+    excluded_patterns: [],
+    raw_pattern: '/user-func2',
+  })
+  expect(routes[2]).toEqual({
+    function: 'framework-func1',
+    pattern: '^/framework-func1/?$',
+    excluded_patterns: [],
+    raw_pattern: '/framework-func1',
+  })
+  expect(routes[3]).toEqual({
+    function: 'user-func1',
+    pattern: '^/user-func1/?$',
+    excluded_patterns: [],
+    raw_pattern: '/user-func1',
+  })
+  expect(routes[4]).toEqual({
+    function: 'user-func3',
+    pattern: '^/user-func3/?$',
+    excluded_patterns: [],
+    raw_pattern: '/user-func3',
+  })
+  expect(routes[5]).toEqual({
+    function: 'user-func5',
+    pattern: '^/user-func5(?:/(.*))/?$',
+    excluded_patterns: [],
+    raw_pattern: '/user-func5/*',
+  })
 
   expect(postCacheRoutes.length).toBe(1)
-  expect(postCacheRoutes[0]).toEqual({ function: 'user-func4', pattern: '^/user-func4/?$', excluded_patterns: [] })
+  expect(postCacheRoutes[0]).toEqual({
+    function: 'user-func4',
+    pattern: '^/user-func4/?$',
+    excluded_patterns: [],
+    raw_pattern: '/user-func4',
+  })
 
   expect(Object.keys(functionConfig)).toHaveLength(1)
   expect(functionConfig['user-func5']).toEqual({

--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -201,37 +201,37 @@ test('Loads function paths from the in-source `config` function', async () => {
     function: 'framework-func2',
     pattern: '^/framework-func2/?$',
     excluded_patterns: [],
-    raw_pattern: '/framework-func2',
+    path: '/framework-func2',
   })
   expect(routes[1]).toEqual({
     function: 'user-func2',
     pattern: '^/user-func2/?$',
     excluded_patterns: [],
-    raw_pattern: '/user-func2',
+    path: '/user-func2',
   })
   expect(routes[2]).toEqual({
     function: 'framework-func1',
     pattern: '^/framework-func1/?$',
     excluded_patterns: [],
-    raw_pattern: '/framework-func1',
+    path: '/framework-func1',
   })
   expect(routes[3]).toEqual({
     function: 'user-func1',
     pattern: '^/user-func1/?$',
     excluded_patterns: [],
-    raw_pattern: '/user-func1',
+    path: '/user-func1',
   })
   expect(routes[4]).toEqual({
     function: 'user-func3',
     pattern: '^/user-func3/?$',
     excluded_patterns: [],
-    raw_pattern: '/user-func3',
+    path: '/user-func3',
   })
   expect(routes[5]).toEqual({
     function: 'user-func5',
     pattern: '^/user-func5(?:/(.*))/?$',
     excluded_patterns: [],
-    raw_pattern: '/user-func5/*',
+    path: '/user-func5/*',
   })
 
   expect(postCacheRoutes.length).toBe(1)
@@ -239,7 +239,7 @@ test('Loads function paths from the in-source `config` function', async () => {
     function: 'user-func4',
     pattern: '^/user-func4/?$',
     excluded_patterns: [],
-    raw_pattern: '/user-func4',
+    path: '/user-func4',
   })
 
   expect(Object.keys(functionConfig)).toHaveLength(1)

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -29,7 +29,7 @@ test('Generates a manifest with different bundles', () => {
     { asset: bundle1.hash + bundle1.extension, format: bundle1.format },
     { asset: bundle2.hash + bundle2.extension, format: bundle2.format },
   ]
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [], raw_pattern: '/f1' }]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [], path: '/f1' }]
 
   expect(manifest.bundles).toEqual(expectedBundles)
   expect(manifest.routes).toEqual(expectedRoutes)
@@ -53,9 +53,7 @@ test('Generates a manifest with display names', () => {
     featureFlags: { edge_functions_path_urlpattern: true },
   })
 
-  const expectedRoutes = [
-    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], raw_pattern: '/f1/*' },
-  ]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], path: '/f1/*' }]
   expect(manifest.function_config).toEqual({
     'func-1': { name: 'Display Name' },
   })
@@ -80,9 +78,7 @@ test('Generates a manifest with a generator field', () => {
     featureFlags: { edge_functions_path_urlpattern: true },
   })
 
-  const expectedRoutes = [
-    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], raw_pattern: '/f1/*' },
-  ]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], path: '/f1/*' }]
   const expectedFunctionConfig = { 'func-1': { generator: '@netlify/fake-plugin@1.0.0' } }
   expect(manifest.routes).toEqual(expectedRoutes)
   expect(manifest.function_config).toEqual(expectedFunctionConfig)
@@ -106,7 +102,7 @@ test('Generates a manifest with excluded paths and patterns', () => {
     featureFlags: { edge_functions_path_urlpattern: true },
   })
   const expectedRoutes = [
-    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: ['^/f1/exclude/?$'], raw_pattern: '/f1/*' },
+    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: ['^/f1/exclude/?$'], path: '/f1/*' },
     {
       function: 'func-2',
       pattern: '^/f2(?:/(.*))/?$',
@@ -116,7 +112,7 @@ test('Generates a manifest with excluded paths and patterns', () => {
       function: 'func-3',
       pattern: '^(?:/(.*))/?$',
       excluded_patterns: ['^(?:/((?:.*)(?:/(?:.*))*))?(?:/(.*))\\.html/?$'],
-      raw_pattern: '/*',
+      path: '/*',
     },
   ]
 
@@ -143,9 +139,7 @@ test('TOML-defined paths can be combined with ISC-defined excluded paths', () =>
     userFunctionConfig,
     featureFlags: { edge_functions_path_urlpattern: true },
   })
-  const expectedRoutes = [
-    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], raw_pattern: '/f1/*' },
-  ]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], path: '/f1/*' }]
 
   expect(manifest.routes).toEqual(expectedRoutes)
   expect(manifest.function_config).toEqual({
@@ -230,13 +224,13 @@ test('excludedPath from ISC goes into function_config, TOML goes into routes', (
       function: 'customisation',
       pattern: '^/showcases(?:/(.*))/?$',
       excluded_patterns: [],
-      raw_pattern: '/showcases/*',
+      path: '/showcases/*',
     },
     {
       function: 'customisation',
       pattern: '^/checkout(?:/(.*))/?$',
       excluded_patterns: ['^(?:/(.*))/terms-and-conditions/?$'],
-      raw_pattern: '/checkout/*',
+      path: '/checkout/*',
     },
   ])
   expect(manifest.function_config).toEqual({
@@ -272,7 +266,7 @@ test('URLPattern named groups are supported', () => {
       function: 'customisation',
       pattern: '^/products(?:/([^/]+?))/?$',
       excluded_patterns: [],
-      raw_pattern: '/products/:productId',
+      path: '/products/:productId',
     },
   ])
 
@@ -332,7 +326,7 @@ test('Excludes functions for which there are function files but no matching conf
   const declarations: Declaration[] = [{ function: 'func-1', path: '/f1' }]
   const manifest = generateManifest({ bundles: [bundle1], declarations, functions })
 
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [], raw_pattern: '/f1' }]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [], path: '/f1' }]
 
   expect(manifest.routes).toEqual(expectedRoutes)
 })
@@ -350,7 +344,7 @@ test('Excludes functions for which there are config declarations but no matching
   ]
   const manifest = generateManifest({ bundles: [bundle1], declarations, functions })
 
-  const expectedRoutes = [{ function: 'func-2', pattern: '^/f2/?$', excluded_patterns: [], raw_pattern: '/f2' }]
+  const expectedRoutes = [{ function: 'func-2', pattern: '^/f2/?$', excluded_patterns: [], path: '/f2' }]
 
   expect(manifest.routes).toEqual(expectedRoutes)
 })
@@ -360,7 +354,7 @@ test('Generates a manifest without bundles', () => {
   const declarations: Declaration[] = [{ function: 'func-1', path: '/f1' }]
   const manifest = generateManifest({ bundles: [], declarations, functions })
 
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [], raw_pattern: '/f1' }]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [], path: '/f1' }]
 
   expect(manifest.bundles).toEqual([])
   expect(manifest.routes).toEqual(expectedRoutes)
@@ -395,11 +389,11 @@ test('Generates a manifest with pre and post-cache routes', () => {
     { asset: bundle2.hash + bundle2.extension, format: bundle2.format },
   ]
   const expectedPreCacheRoutes = [
-    { function: 'func-1', name: undefined, pattern: '^/f1/?$', excluded_patterns: [], raw_pattern: '/f1' },
-    { function: 'func-2', name: undefined, pattern: '^/f2/?$', excluded_patterns: [], raw_pattern: '/f2' },
+    { function: 'func-1', name: undefined, pattern: '^/f1/?$', excluded_patterns: [], path: '/f1' },
+    { function: 'func-2', name: undefined, pattern: '^/f2/?$', excluded_patterns: [], path: '/f2' },
   ]
   const expectedPostCacheRoutes = [
-    { function: 'func-3', name: undefined, pattern: '^/f3/?$', excluded_patterns: [], raw_pattern: '/f3' },
+    { function: 'func-3', name: undefined, pattern: '^/f3/?$', excluded_patterns: [], path: '/f3' },
   ]
 
   expect(manifest.bundles).toEqual(expectedBundles)
@@ -418,8 +412,8 @@ test('Generates a manifest with layers', () => {
     { function: 'func-2', path: '/f2/*' },
   ]
   const expectedRoutes = [
-    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], raw_pattern: '/f1/*' },
-    { function: 'func-2', pattern: '^/f2(?:/(.*))/?$', excluded_patterns: [], raw_pattern: '/f2/*' },
+    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], path: '/f1/*' },
+    { function: 'func-2', pattern: '^/f2(?:/(.*))/?$', excluded_patterns: [], path: '/f2/*' },
   ]
   const layers = [
     {

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -29,7 +29,7 @@ test('Generates a manifest with different bundles', () => {
     { asset: bundle1.hash + bundle1.extension, format: bundle1.format },
     { asset: bundle2.hash + bundle2.extension, format: bundle2.format },
   ]
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [] }]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [], raw_pattern: '/f1' }]
 
   expect(manifest.bundles).toEqual(expectedBundles)
   expect(manifest.routes).toEqual(expectedRoutes)
@@ -53,7 +53,9 @@ test('Generates a manifest with display names', () => {
     featureFlags: { edge_functions_path_urlpattern: true },
   })
 
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [] }]
+  const expectedRoutes = [
+    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], raw_pattern: '/f1/*' },
+  ]
   expect(manifest.function_config).toEqual({
     'func-1': { name: 'Display Name' },
   })
@@ -78,7 +80,9 @@ test('Generates a manifest with a generator field', () => {
     featureFlags: { edge_functions_path_urlpattern: true },
   })
 
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [] }]
+  const expectedRoutes = [
+    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], raw_pattern: '/f1/*' },
+  ]
   const expectedFunctionConfig = { 'func-1': { generator: '@netlify/fake-plugin@1.0.0' } }
   expect(manifest.routes).toEqual(expectedRoutes)
   expect(manifest.function_config).toEqual(expectedFunctionConfig)
@@ -102,12 +106,17 @@ test('Generates a manifest with excluded paths and patterns', () => {
     featureFlags: { edge_functions_path_urlpattern: true },
   })
   const expectedRoutes = [
-    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: ['^/f1/exclude/?$'] },
-    { function: 'func-2', pattern: '^/f2(?:/(.*))/?$', excluded_patterns: ['^/f2/exclude$', '^/f2/exclude-as-well$'] },
+    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: ['^/f1/exclude/?$'], raw_pattern: '/f1/*' },
+    {
+      function: 'func-2',
+      pattern: '^/f2(?:/(.*))/?$',
+      excluded_patterns: ['^/f2/exclude$', '^/f2/exclude-as-well$'],
+    },
     {
       function: 'func-3',
       pattern: '^(?:/(.*))/?$',
       excluded_patterns: ['^(?:/((?:.*)(?:/(?:.*))*))?(?:/(.*))\\.html/?$'],
+      raw_pattern: '/*',
     },
   ]
 
@@ -134,7 +143,9 @@ test('TOML-defined paths can be combined with ISC-defined excluded paths', () =>
     userFunctionConfig,
     featureFlags: { edge_functions_path_urlpattern: true },
   })
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [] }]
+  const expectedRoutes = [
+    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], raw_pattern: '/f1/*' },
+  ]
 
   expect(manifest.routes).toEqual(expectedRoutes)
   expect(manifest.function_config).toEqual({
@@ -219,11 +230,13 @@ test('excludedPath from ISC goes into function_config, TOML goes into routes', (
       function: 'customisation',
       pattern: '^/showcases(?:/(.*))/?$',
       excluded_patterns: [],
+      raw_pattern: '/showcases/*',
     },
     {
       function: 'customisation',
       pattern: '^/checkout(?:/(.*))/?$',
       excluded_patterns: ['^(?:/(.*))/terms-and-conditions/?$'],
+      raw_pattern: '/checkout/*',
     },
   ])
   expect(manifest.function_config).toEqual({
@@ -259,6 +272,7 @@ test('URLPattern named groups are supported', () => {
       function: 'customisation',
       pattern: '^/products(?:/([^/]+?))/?$',
       excluded_patterns: [],
+      raw_pattern: '/products/:productId',
     },
   ])
 
@@ -318,7 +332,7 @@ test('Excludes functions for which there are function files but no matching conf
   const declarations: Declaration[] = [{ function: 'func-1', path: '/f1' }]
   const manifest = generateManifest({ bundles: [bundle1], declarations, functions })
 
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [] }]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [], raw_pattern: '/f1' }]
 
   expect(manifest.routes).toEqual(expectedRoutes)
 })
@@ -336,7 +350,7 @@ test('Excludes functions for which there are config declarations but no matching
   ]
   const manifest = generateManifest({ bundles: [bundle1], declarations, functions })
 
-  const expectedRoutes = [{ function: 'func-2', pattern: '^/f2/?$', excluded_patterns: [] }]
+  const expectedRoutes = [{ function: 'func-2', pattern: '^/f2/?$', excluded_patterns: [], raw_pattern: '/f2' }]
 
   expect(manifest.routes).toEqual(expectedRoutes)
 })
@@ -346,7 +360,7 @@ test('Generates a manifest without bundles', () => {
   const declarations: Declaration[] = [{ function: 'func-1', path: '/f1' }]
   const manifest = generateManifest({ bundles: [], declarations, functions })
 
-  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [] }]
+  const expectedRoutes = [{ function: 'func-1', pattern: '^/f1/?$', excluded_patterns: [], raw_pattern: '/f1' }]
 
   expect(manifest.bundles).toEqual([])
   expect(manifest.routes).toEqual(expectedRoutes)
@@ -381,10 +395,12 @@ test('Generates a manifest with pre and post-cache routes', () => {
     { asset: bundle2.hash + bundle2.extension, format: bundle2.format },
   ]
   const expectedPreCacheRoutes = [
-    { function: 'func-1', name: undefined, pattern: '^/f1/?$', excluded_patterns: [] },
-    { function: 'func-2', name: undefined, pattern: '^/f2/?$', excluded_patterns: [] },
+    { function: 'func-1', name: undefined, pattern: '^/f1/?$', excluded_patterns: [], raw_pattern: '/f1' },
+    { function: 'func-2', name: undefined, pattern: '^/f2/?$', excluded_patterns: [], raw_pattern: '/f2' },
   ]
-  const expectedPostCacheRoutes = [{ function: 'func-3', name: undefined, pattern: '^/f3/?$', excluded_patterns: [] }]
+  const expectedPostCacheRoutes = [
+    { function: 'func-3', name: undefined, pattern: '^/f3/?$', excluded_patterns: [], raw_pattern: '/f3' },
+  ]
 
   expect(manifest.bundles).toEqual(expectedBundles)
   expect(manifest.routes).toEqual(expectedPreCacheRoutes)
@@ -402,8 +418,8 @@ test('Generates a manifest with layers', () => {
     { function: 'func-2', path: '/f2/*' },
   ]
   const expectedRoutes = [
-    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [] },
-    { function: 'func-2', pattern: '^/f2(?:/(.*))/?$', excluded_patterns: [] },
+    { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], raw_pattern: '/f1/*' },
+    { function: 'func-2', pattern: '^/f2(?:/(.*))/?$', excluded_patterns: [], raw_pattern: '/f2/*' },
   ]
   const layers = [
     {

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -18,6 +18,7 @@ interface Route {
   function: string
   pattern: string
   excluded_patterns: string[]
+  raw_pattern?: string
 }
 
 interface EdgeFunctionConfig {
@@ -139,6 +140,10 @@ const generateManifest = ({
       function: func.name,
       pattern: serializePattern(pattern),
       excluded_patterns: excludedPattern.map(serializePattern),
+    }
+
+    if ('path' in declaration) {
+      route.raw_pattern = declaration.path
     }
 
     if (declaration.cache === Cache.Manual) {

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -18,7 +18,7 @@ interface Route {
   function: string
   pattern: string
   excluded_patterns: string[]
-  raw_pattern?: string
+  path?: string
 }
 
 interface EdgeFunctionConfig {
@@ -143,7 +143,7 @@ const generateManifest = ({
     }
 
     if ('path' in declaration) {
-      route.raw_pattern = declaration.path
+      route.path = declaration.path
     }
 
     if (declaration.cache === Cache.Manual) {

--- a/node/validation/manifest/schema.ts
+++ b/node/validation/manifest/schema.ts
@@ -31,6 +31,7 @@ const routesSchema = {
     },
     excluded_patterns: excludedPatternsSchema,
     generator: { type: 'string' },
+    raw_pattern: { type: 'string' },
   },
   additionalProperties: false,
 }

--- a/node/validation/manifest/schema.ts
+++ b/node/validation/manifest/schema.ts
@@ -31,7 +31,7 @@ const routesSchema = {
     },
     excluded_patterns: excludedPatternsSchema,
     generator: { type: 'string' },
-    raw_pattern: { type: 'string' },
+    path: { type: 'string' },
   },
   additionalProperties: false,
 }


### PR DESCRIPTION
Adds a `path` property to the manifest file containing the original path defined for the function, before any transformations to regular expressions.

Part of https://github.com/netlify/pod-dev-foundations/issues/459.