### PR TITLE
feat: support `@netlify/edge-functions` specifier

### DIFF
--- a/deno/lib/consts.ts
+++ b/deno/lib/consts.ts
@@ -1,4 +1,5 @@
-export const PUBLIC_SPECIFIER = 'netlify:edge'
+export const LEGACY_PUBLIC_SPECIFIER = 'netlify:edge'
+export const PUBLIC_SPECIFIER = '@netlify/edge-functions'
 export const STAGE1_SPECIFIER = 'netlify:bootstrap-stage1'
 export const STAGE2_SPECIFIER = 'netlify:bootstrap-stage2'
 export const virtualRoot = 'file:///root/'

--- a/deno/lib/stage2.ts
+++ b/deno/lib/stage2.ts
@@ -4,7 +4,7 @@ import * as path from 'https://deno.land/std@0.177.0/path/mod.ts'
 
 import type { InputFunction, WriteStage2Options } from '../../shared/stage2.ts'
 import { importMapSpecifier, virtualRoot } from '../../shared/consts.ts'
-import { PUBLIC_SPECIFIER, STAGE2_SPECIFIER } from './consts.ts'
+import { LEGACY_PUBLIC_SPECIFIER, PUBLIC_SPECIFIER, STAGE2_SPECIFIER } from './consts.ts'
 import { inlineModule, loadFromVirtualRoot, loadWithRetry } from './common.ts'
 
 interface FunctionReference {
@@ -75,7 +75,12 @@ const stage2Loader = (basePath: string, functions: InputFunction[], externals: S
       return inlineModule(specifier, importMapData)
     }
 
-    if (specifier === PUBLIC_SPECIFIER || externals.has(specifier) || specifier.startsWith('node:')) {
+    if (
+      specifier === LEGACY_PUBLIC_SPECIFIER ||
+      specifier === PUBLIC_SPECIFIER ||
+      externals.has(specifier) ||
+      specifier.startsWith('node:')
+    ) {
       return {
         kind: 'external',
         specifier,

--- a/node/import_map.test.ts
+++ b/node/import_map.test.ts
@@ -80,6 +80,7 @@ describe('Returns the fully resolved import map', () => {
       specifier3: 'file:///different/full/path/file3.js',
       specifier2: 'file:///some/full/path/file2.js',
       specifier1: 'file:///some/full/path/file.js',
+      '@netlify/edge-functions': 'https://edge.netlify.com/v1/index.ts',
       'netlify:edge': 'https://edge.netlify.com/v1/index.ts',
     })
 
@@ -104,6 +105,7 @@ describe('Returns the fully resolved import map', () => {
       specifier3: 'file:///vendor/full/path/file3.js',
       specifier2: 'file:///root/full/path/file2.js',
       specifier1: 'file:///root/full/path/file.js',
+      '@netlify/edge-functions': 'https://edge.netlify.com/v1/index.ts',
       'netlify:edge': 'https://edge.netlify.com/v1/index.ts',
     })
 

--- a/node/import_map.ts
+++ b/node/import_map.ts
@@ -9,6 +9,7 @@ import { Logger } from './logger.js'
 import { isFileNotFoundError } from './utils/error.js'
 
 const INTERNAL_IMPORTS = {
+  '@netlify/edge-functions': 'https://edge.netlify.com/v1/index.ts',
   'netlify:edge': 'https://edge.netlify.com/v1/index.ts',
 }
 

--- a/test/fixtures/with_config/netlify/edge-functions/user-func1.ts
+++ b/test/fixtures/with_config/netlify/edge-functions/user-func1.ts
@@ -1,3 +1,4 @@
+import { Config } from '@netlify/edge-functions'
 import { greet } from 'alias:helper'
 
 // Accessing `Deno.env` in the global scope
@@ -11,6 +12,6 @@ export default async () => {
   return new Response(greeting)
 }
 
-export const config = {
+export const config: Config = {
   path: '/user-func1',
 }


### PR DESCRIPTION
**Which problem is this pull request solving?**

Adds support for loading the types from the `@netlify/edge-functions` specifier. Support for `netlify:edge` is maintained for backwards-compatibility.

**List other issues or pull requests related to this problem**

Closes https://github.com/netlify/pod-dev-foundations/issues/417.