### PR TITLE
feat: remove `URLPattern` feature flag

### DIFF
--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -181,7 +181,6 @@ test('Loads function paths from the in-source `config` function', async () => {
   const result = await bundle([internalDirectory, userDirectory], distPath, declarations, {
     basePath,
     configPath: join(internalDirectory, 'config.json'),
-    featureFlags: { edge_functions_path_urlpattern: true },
   })
   const generatedFiles = await fs.readdir(distPath)
 

--- a/node/feature_flags.ts
+++ b/node/feature_flags.ts
@@ -1,6 +1,5 @@
 const defaultFlags = {
   edge_functions_fail_unsupported_regex: false,
-  edge_functions_path_urlpattern: false,
 }
 
 type FeatureFlag = keyof typeof defaultFlags

--- a/node/manifest.test.ts
+++ b/node/manifest.test.ts
@@ -50,7 +50,6 @@ test('Generates a manifest with display names', () => {
     declarations,
     functions,
     internalFunctionConfig,
-    featureFlags: { edge_functions_path_urlpattern: true },
   })
 
   const expectedRoutes = [{ function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], path: '/f1/*' }]
@@ -75,7 +74,6 @@ test('Generates a manifest with a generator field', () => {
     declarations,
     functions,
     internalFunctionConfig,
-    featureFlags: { edge_functions_path_urlpattern: true },
   })
 
   const expectedRoutes = [{ function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], path: '/f1/*' }]
@@ -99,7 +97,6 @@ test('Generates a manifest with excluded paths and patterns', () => {
     bundles: [],
     declarations,
     functions,
-    featureFlags: { edge_functions_path_urlpattern: true },
   })
   const expectedRoutes = [
     { function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: ['^/f1/exclude/?$'], path: '/f1/*' },
@@ -137,7 +134,6 @@ test('TOML-defined paths can be combined with ISC-defined excluded paths', () =>
     declarations,
     functions,
     userFunctionConfig,
-    featureFlags: { edge_functions_path_urlpattern: true },
   })
   const expectedRoutes = [{ function: 'func-1', pattern: '^/f1(?:/(.*))/?$', excluded_patterns: [], path: '/f1/*' }]
 
@@ -217,7 +213,6 @@ test('excludedPath from ISC goes into function_config, TOML goes into routes', (
     functions,
     userFunctionConfig,
     internalFunctionConfig,
-    featureFlags: { edge_functions_path_urlpattern: true },
   })
   expect(manifest.routes).toEqual([
     {
@@ -259,7 +254,6 @@ test('URLPattern named groups are supported', () => {
     functions,
     userFunctionConfig,
     internalFunctionConfig,
-    featureFlags: { edge_functions_path_urlpattern: true },
   })
   expect(manifest.routes).toEqual([
     {
@@ -288,7 +282,6 @@ test('Invalid Path patterns throw bundling errors', () => {
       functions,
       userFunctionConfig,
       internalFunctionConfig,
-      featureFlags: { edge_functions_path_urlpattern: true },
     }),
   ).toThrowError(BundleError)
 })
@@ -425,14 +418,12 @@ test('Generates a manifest with layers', () => {
     bundles: [],
     declarations,
     functions,
-    featureFlags: { edge_functions_path_urlpattern: true },
   })
   const manifest2 = generateManifest({
     bundles: [],
     declarations,
     functions,
     layers,
-    featureFlags: { edge_functions_path_urlpattern: true },
   })
 
   expect(manifest1.routes).toEqual(expectedRoutes)

--- a/node/manifest.ts
+++ b/node/manifest.ts
@@ -1,8 +1,6 @@
 import { promises as fs } from 'fs'
 import { join } from 'path'
 
-import globToRegExp from 'glob-to-regexp'
-
 import type { Bundle } from './bundle.js'
 import { wrapBundleError } from './bundle_error.js'
 import { Cache, FunctionConfig, Path } from './config.js'
@@ -80,11 +78,10 @@ const addExcludedPatterns = (
   name: string,
   manifestFunctionConfig: Record<string, EdgeFunctionConfig>,
   excludedPath?: Path | Path[],
-  featureFlags?: FeatureFlags,
 ) => {
   if (excludedPath) {
     const paths = Array.isArray(excludedPath) ? excludedPath : [excludedPath]
-    const excludedPatterns = paths.map((path) => pathToRegularExpression(path, featureFlags)).map(serializePattern)
+    const excludedPatterns = paths.map((path) => pathToRegularExpression(path)).map(serializePattern)
 
     manifestFunctionConfig[name].excluded_patterns.push(...excludedPatterns)
   }
@@ -111,7 +108,7 @@ const generateManifest = ({
     if (manifestFunctionConfig[name] === undefined) {
       continue
     }
-    addExcludedPatterns(name, manifestFunctionConfig, excludedPath, featureFlags)
+    addExcludedPatterns(name, manifestFunctionConfig, excludedPath)
 
     manifestFunctionConfig[name] = { ...manifestFunctionConfig[name], on_error: onError }
   }
@@ -121,7 +118,7 @@ const generateManifest = ({
     if (manifestFunctionConfig[name] === undefined) {
       continue
     }
-    addExcludedPatterns(name, manifestFunctionConfig, excludedPath, featureFlags)
+    addExcludedPatterns(name, manifestFunctionConfig, excludedPath)
 
     manifestFunctionConfig[name] = { ...manifestFunctionConfig[name], on_error: onError, ...rest }
   }
@@ -169,36 +166,23 @@ const generateManifest = ({
   return manifest
 }
 
-const pathToRegularExpression = (path: string, featureFlags?: FeatureFlags) => {
-  if (featureFlags?.edge_functions_path_urlpattern) {
-    try {
-      const pattern = new ExtendedURLPattern({ pathname: path })
+const pathToRegularExpression = (path: string) => {
+  try {
+    const pattern = new ExtendedURLPattern({ pathname: path })
 
-      // Removing the `^` and `$` delimiters because we'll need to modify what's
-      // between them.
-      const source = pattern.regexp.pathname.source.slice(1, -1)
+    // Removing the `^` and `$` delimiters because we'll need to modify what's
+    // between them.
+    const source = pattern.regexp.pathname.source.slice(1, -1)
 
-      // Wrapping the expression source with `^` and `$`. Also, adding an optional
-      // trailing slash, so that a declaration of `path: "/foo"` matches requests
-      // for both `/foo` and `/foo/`.
-      const normalizedSource = `^${source}\\/?$`
+    // Wrapping the expression source with `^` and `$`. Also, adding an optional
+    // trailing slash, so that a declaration of `path: "/foo"` matches requests
+    // for both `/foo` and `/foo/`.
+    const normalizedSource = `^${source}\\/?$`
 
-      return normalizedSource
-    } catch (error) {
-      throw wrapBundleError(error)
-    }
+    return normalizedSource
+  } catch (error) {
+    throw wrapBundleError(error)
   }
-
-  // We use the global flag so that `globToRegExp` will not wrap the expression
-  // with `^` and `$`. We'll do that ourselves.
-  const regularExpression = globToRegExp(path, { flags: 'g' })
-
-  // Wrapping the expression source with `^` and `$`. Also, adding an optional
-  // trailing slash, so that a declaration of `path: "/foo"` matches requests
-  // for both `/foo` and `/foo/`.
-  const normalizedSource = `^${regularExpression.source}\\/?$`
-
-  return normalizedSource
 }
 
 const getRegularExpression = (declaration: Declaration, featureFlags?: FeatureFlags): string => {
@@ -223,7 +207,7 @@ const getRegularExpression = (declaration: Declaration, featureFlags?: FeatureFl
     }
   }
 
-  return pathToRegularExpression(declaration.path, featureFlags)
+  return pathToRegularExpression(declaration.path)
 }
 
 const getExcludedRegularExpressions = (declaration: Declaration, featureFlags?: FeatureFlags): string[] => {
@@ -254,7 +238,7 @@ const getExcludedRegularExpressions = (declaration: Declaration, featureFlags?: 
 
   if ('path' in declaration && declaration.excludedPath) {
     const paths = Array.isArray(declaration.excludedPath) ? declaration.excludedPath : [declaration.excludedPath]
-    return paths.map((path) => pathToRegularExpression(path, featureFlags))
+    return paths.map((path) => pathToRegularExpression(path))
   }
 
   return []

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "execa": "^6.0.0",
         "find-up": "^6.3.0",
         "get-port": "^6.1.2",
-        "glob-to-regexp": "^0.4.1",
         "is-path-inside": "^4.0.0",
         "jsonc-parser": "^3.2.0",
         "node-fetch": "^3.1.1",
@@ -4981,11 +4980,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/global-dirs": {
       "version": "0.1.1",
@@ -12798,11 +12792,6 @@
       "requires": {
         "is-glob": "^4.0.3"
       }
-    },
-    "glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "global-dirs": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "execa": "^6.0.0",
     "find-up": "^6.3.0",
     "get-port": "^6.1.2",
-    "glob-to-regexp": "^0.4.1",
     "is-path-inside": "^4.0.0",
     "jsonc-parser": "^3.2.0",
     "node-fetch": "^3.1.1",


### PR DESCRIPTION
**Which problem is this pull request solving?**

Removes the feature flag added in https://github.com/netlify/edge-bundler/pull/392, which has now been fully rolled out.

The `URLPattern` format is now a requirement for https://github.com/netlify/pod-dev-foundations/issues/459.