### PR TITLE
fix: hide stack trace on syntax errors

### DIFF
--- a/deno/bundle.ts
+++ b/deno/bundle.ts
@@ -3,4 +3,14 @@ import { writeStage2 } from './lib/stage2.ts'
 const [payload] = Deno.args
 const { basePath, destPath, externals, functions, importMapData } = JSON.parse(payload)
 
-await writeStage2({ basePath, destPath, externals, functions, importMapData })
+try {
+  await writeStage2({ basePath, destPath, externals, functions, importMapData })
+} catch (error) {
+  if (error instanceof Error) {
+    if (error.message.includes("The module's source code could not be parsed")) {
+      delete error.stack
+    }
+  }
+
+  throw error
+}

--- a/deno/bundle.ts
+++ b/deno/bundle.ts
@@ -6,10 +6,8 @@ const { basePath, destPath, externals, functions, importMapData } = JSON.parse(p
 try {
   await writeStage2({ basePath, destPath, externals, functions, importMapData })
 } catch (error) {
-  if (error instanceof Error) {
-    if (error.message.includes("The module's source code could not be parsed")) {
-      delete error.stack
-    }
+  if (error instanceof Error && error.message.includes("The module's source code could not be parsed")) {
+    delete error.stack
   }
 
   throw error

--- a/node/bundle_error.ts
+++ b/node/bundle_error.ts
@@ -1,3 +1,5 @@
+import type { ExecaError } from 'execa'
+
 interface BundleErrorOptions {
   format: string
 }
@@ -30,6 +32,11 @@ class BundleError extends Error {
  */
 const wrapBundleError = (input: unknown, options?: BundleErrorOptions) => {
   if (input instanceof Error) {
+    if (input.message.includes("The module's source code could not be parsed")) {
+      // eslint-disable-next-line no-param-reassign
+      input.message = (input as ExecaError).stderr
+    }
+
     return new BundleError(input, options)
   }
 

--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -86,7 +86,7 @@ test('Uses the vendored eszip module instead of fetching it from deno.land', asy
   await cleanup()
 })
 
-test('Adds a custom error property to user errors during bundling', async () => {
+test.only('Adds a custom error property to user errors during bundling', async () => {
   process.env.NO_COLOR = 'true'
   expect.assertions(3)
 
@@ -103,14 +103,15 @@ test('Adds a custom error property to user errors during bundling', async () => 
     await bundle([sourceDirectory], distPath, declarations, { basePath })
   } catch (error) {
     expect(error).toBeInstanceOf(BundleError)
-    expect((error as BundleError).message).toMatchInlineSnapshot(`
+    const [messageBeforeStack] = (error as BundleError).message.split('at <anonymous> (file://')
+    expect(messageBeforeStack).toMatchInlineSnapshot(`
       "error: Uncaught (in promise) Error: The module's source code could not be parsed: Unexpected eof at file:///root/functions/func1.ts:1:27
 
         export default async () => 
                                   ~
             const ret = new Error(getStringFromWasm0(arg0, arg1));
                         ^
-          at <anonymous> (file:///Users/skn0tt/dev/netlify/edge-bundler/deno/vendor/deno.land/x/eszip@v0.40.0/eszip_wasm.generated.js:417:19)"
+          "
     `)
     expect((error as BundleError).customErrorInfo).toEqual({
       location: {

--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -86,7 +86,7 @@ test('Uses the vendored eszip module instead of fetching it from deno.land', asy
   await cleanup()
 })
 
-test.only('Adds a custom error property to user errors during bundling', async () => {
+test('Adds a custom error property to user errors during bundling', async () => {
   process.env.NO_COLOR = 'true'
   expect.assertions(3)
 

--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -102,7 +102,8 @@ test('Adds a custom error property to user errors during bundling', async () => 
   try {
     await bundle([sourceDirectory], distPath, declarations, { basePath })
   } catch (error) {
-    expect(error.message).toMatchInlineSnapshot(`
+    expect(error).toBeInstanceOf(BundleError)
+    expect((error as BundleError).message).toMatchInlineSnapshot(`
       "error: Uncaught (in promise) Error: The module's source code could not be parsed: Unexpected eof at file:///root/functions/func1.ts:1:27
 
         export default async () => 
@@ -111,7 +112,6 @@ test('Adds a custom error property to user errors during bundling', async () => 
                         ^
           at <anonymous> (file:///Users/skn0tt/dev/netlify/edge-bundler/deno/vendor/deno.land/x/eszip@v0.40.0/eszip_wasm.generated.js:417:19)"
     `)
-    expect(error).toBeInstanceOf(BundleError)
     expect((error as BundleError).customErrorInfo).toEqual({
       location: {
         format: 'eszip',

--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -87,7 +87,8 @@ test('Uses the vendored eszip module instead of fetching it from deno.land', asy
 })
 
 test('Adds a custom error property to user errors during bundling', async () => {
-  expect.assertions(2)
+  process.env.NO_COLOR = 'true'
+  expect.assertions(3)
 
   const { basePath, cleanup, distPath } = await useFixture('invalid_functions')
   const sourceDirectory = join(basePath, 'functions')
@@ -101,6 +102,15 @@ test('Adds a custom error property to user errors during bundling', async () => 
   try {
     await bundle([sourceDirectory], distPath, declarations, { basePath })
   } catch (error) {
+    expect(error.message).toMatchInlineSnapshot(`
+      "error: Uncaught (in promise) Error: The module's source code could not be parsed: Unexpected eof at file:///root/functions/func1.ts:1:27
+
+        export default async () => 
+                                  ~
+            const ret = new Error(getStringFromWasm0(arg0, arg1));
+                        ^
+          at <anonymous> (file:///Users/skn0tt/dev/netlify/edge-bundler/deno/vendor/deno.land/x/eszip@v0.40.0/eszip_wasm.generated.js:417:19)"
+    `)
     expect(error).toBeInstanceOf(BundleError)
     expect((error as BundleError).customErrorInfo).toEqual({
       location: {


### PR DESCRIPTION
Closes https://github.com/netlify/pod-dev-foundations/issues/580.