### PR TITLE
fix: remap `netlify:edge` specifier

### DIFF
--- a/node/import_map.test.ts
+++ b/node/import_map.test.ts
@@ -26,7 +26,8 @@ test('Handles import maps with full URLs without specifying a base URL', () => {
   const map = new ImportMap([inputFile1, inputFile2])
   const { imports } = map.getContents()
 
-  expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
+  expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts?v=legacy')
+  expect(imports['@netlify/edge-functions']).toBe('https://edge.netlify.com/v1/index.ts')
   expect(imports['alias:jamstack']).toBe('https://jamstack.org/')
   expect(imports['alias:pets']).toBe('https://petsofnetlify.com/')
 })
@@ -44,7 +45,8 @@ test('Resolves relative paths to absolute paths if a base path is not provided',
   const { imports } = map.getContents()
   const expectedPath = join(cwd(), 'my-cool-site', 'heart', 'pets')
 
-  expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
+  expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts?v=legacy')
+  expect(imports['@netlify/edge-functions']).toBe('https://edge.netlify.com/v1/index.ts')
   expect(imports['alias:pets']).toBe(`${pathToFileURL(expectedPath).toString()}/`)
 })
 
@@ -81,7 +83,7 @@ describe('Returns the fully resolved import map', () => {
       specifier2: 'file:///some/full/path/file2.js',
       specifier1: 'file:///some/full/path/file.js',
       '@netlify/edge-functions': 'https://edge.netlify.com/v1/index.ts',
-      'netlify:edge': 'https://edge.netlify.com/v1/index.ts',
+      'netlify:edge': 'https://edge.netlify.com/v1/index.ts?v=legacy',
     })
 
     expect(scopes).toStrictEqual({
@@ -106,7 +108,7 @@ describe('Returns the fully resolved import map', () => {
       specifier2: 'file:///root/full/path/file2.js',
       specifier1: 'file:///root/full/path/file.js',
       '@netlify/edge-functions': 'https://edge.netlify.com/v1/index.ts',
-      'netlify:edge': 'https://edge.netlify.com/v1/index.ts',
+      'netlify:edge': 'https://edge.netlify.com/v1/index.ts?v=legacy',
     })
 
     expect(scopes).toStrictEqual({
@@ -154,6 +156,7 @@ test('Writes import map file to disk', async () => {
 
   await file.cleanup()
 
-  expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts')
+  expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts?v=legacy')
+  expect(imports['@netlify/edge-functions']).toBe('https://edge.netlify.com/v1/index.ts')
   expect(imports['alias:pets']).toBe(pathToFileURL(expectedPath).toString())
 })

--- a/node/import_map.ts
+++ b/node/import_map.ts
@@ -10,7 +10,7 @@ import { isFileNotFoundError } from './utils/error.js'
 
 const INTERNAL_IMPORTS = {
   '@netlify/edge-functions': 'https://edge.netlify.com/v1/index.ts',
-  'netlify:edge': 'https://edge.netlify.com/v1/index.ts',
+  'netlify:edge': 'https://edge.netlify.com/v1/index.ts?v=legacy',
 }
 
 type Imports = Record<string, string>


### PR DESCRIPTION
**Which problem is this pull request solving?**

Since https://github.com/netlify/edge-bundler/pull/459 landed, we now have two specifiers (`@netlify/edge-functions` and the legacy `netlify:edge`) mapping to https://edge.netlify.com/v1/index.ts. For some reason, this makes the Deno extension in VS Code show a message saying that the former could be renamed to the latter, which is not something we want to suggest.

To prevent that while keeping support for the legacy specifier, we can remap it to a different but equivalent URL (by adding a query parameter), so that the extension sees them as two different URLs.