### PR TITLE
fix: pin bootstrap version used in config extraction

### DIFF
--- a/deno/config.ts
+++ b/deno/config.ts
@@ -1,7 +1,9 @@
-const [functionURL, collectorURL, bootstrapURL, rawExitCodes] = Deno.args
+// this needs to be updated whenever there's a change to globalThis.Netlify in bootstrap
+import { Netlify } from "https://64e8753eae24930008fac6d9--edge.netlify.app/bootstrap/index-combined.ts"
+
+const [functionURL, collectorURL, rawExitCodes] = Deno.args
 const exitCodes = JSON.parse(rawExitCodes)
 
-const { Netlify } = await import(bootstrapURL)
 globalThis.Netlify = Netlify
 
 let func

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -50,7 +50,6 @@ const bundle = async (
     onBeforeDownload,
     systemLogger,
     internalSrcFolder,
-    bootstrapURL = 'https://edge.netlify.com/bootstrap/index-combined.ts',
   }: BundleOptions = {},
 ) => {
   const logger = getLogger(systemLogger, debug)
@@ -115,11 +114,11 @@ const bundle = async (
   // Retrieving a configuration object for each function.
   // Run `getFunctionConfig` in parallel as it is a non-trivial operation and spins up deno
   const internalConfigPromises = internalFunctions.map(
-    async (func) => [func.name, await getFunctionConfig({ func, importMap, deno, log: logger, bootstrapURL })] as const,
+    async (func) => [func.name, await getFunctionConfig({ func, importMap, deno, log: logger })] as const,
   )
 
   const userConfigPromises = userFunctions.map(
-    async (func) => [func.name, await getFunctionConfig({ func, importMap, deno, log: logger, bootstrapURL })] as const,
+    async (func) => [func.name, await getFunctionConfig({ func, importMap, deno, log: logger })] as const,
   )
 
   // Creating a hash of function names to configuration objects.

--- a/node/config.test.ts
+++ b/node/config.test.ts
@@ -14,8 +14,6 @@ import { FunctionConfig, getFunctionConfig } from './config.js'
 import type { Declaration } from './declaration.js'
 import { ImportMap } from './import_map.js'
 
-const bootstrapURL = 'https://edge.netlify.com/bootstrap/index-combined.ts'
-
 const importMapFile = {
   baseURL: new URL('file:///some/path/import-map.json'),
   imports: {
@@ -146,7 +144,6 @@ describe('`getFunctionConfig` extracts configuration properties from function fi
         importMap: new ImportMap([importMapFile]),
         deno,
         log: logger,
-        bootstrapURL,
       })
 
     if (func.error) {
@@ -284,7 +281,6 @@ test('Passes validation if default export exists and is a function', async () =>
       importMap: new ImportMap([importMapFile]),
       deno,
       log: logger,
-      bootstrapURL,
     }),
   ).resolves.not.toThrow()
 
@@ -321,7 +317,6 @@ test('Fails validation if default export is not function', async () => {
     importMap: new ImportMap([importMapFile]),
     deno,
     log: logger,
-    bootstrapURL,
   })
 
   await expect(config).rejects.toThrowError(invalidDefaultExportErr(path))
@@ -358,7 +353,6 @@ test('Fails validation if default export is not present', async () => {
     importMap: new ImportMap([importMapFile]),
     deno,
     log: logger,
-    bootstrapURL,
   })
 
   await expect(config).rejects.toThrowError(invalidDefaultExportErr(path))

--- a/node/config.ts
+++ b/node/config.ts
@@ -59,13 +59,11 @@ export const getFunctionConfig = async ({
   func,
   importMap,
   deno,
-  bootstrapURL,
   log,
 }: {
   func: EdgeFunction
   importMap: ImportMap
   deno: DenoBridge
-  bootstrapURL: string
   log: Logger
 }) => {
   // The extractor is a Deno script that will import the function and run its
@@ -94,7 +92,6 @@ export const getFunctionConfig = async ({
       extractorPath,
       pathToFileURL(func.path).href,
       pathToFileURL(collector.path).href,
-      bootstrapURL,
       JSON.stringify(ConfigExitCode),
     ],
     { rejectOnExitCode: false },

--- a/node/server/server.ts
+++ b/node/server/server.ts
@@ -88,7 +88,7 @@ const prepareServer = ({
 
     if (options.getFunctionsConfig) {
       functionsConfig = await Promise.all(
-        functions.map((func) => getFunctionConfig({ func, importMap, deno, bootstrapURL, log: logger })),
+        functions.map((func) => getFunctionConfig({ func, importMap, deno, log: logger })),
       )
     }
 


### PR DESCRIPTION
We've seen problems with using a non-pinned version of `edge.netlify.com`, since Deno appears to sometimes seems to combine files from cache with fresh files from `edge.netlify.com`. Since `edge.netlify.com` isn't immutable, that can lead to clashes - the fresh files are incompatible with the older cached files.

To ensure this doesn't happen, this PR pins down the bootstrap deploy that's used to infer the config.

To reduce complexity, I didn't just update the default value, bot removed the possibility to inject the version altogether. This ensures CLI and Buildbot behave the same, when they're on the same version of edge-bundler, making debugging a little easier.

Related to https://github.com/netlify/cli/pull/5936.