### PR TITLE
feat!: support npm modules when serving

### DIFF
--- a/node/import_map.test.ts
+++ b/node/import_map.test.ts
@@ -144,7 +144,7 @@ test('Throws when an import map uses a relative path to reference a file outside
     },
   }
 
-  const map = new ImportMap([inputFile1], pathToFileURL(cwd()).toString())
+  const map = new ImportMap([inputFile1], cwd())
 
   expect(() => map.getContents()).toThrowError(
     `Import map cannot reference '${join(cwd(), '..', 'file.js')}' as it's outside of the base directory '${cwd()}'`,
@@ -174,4 +174,51 @@ test('Writes import map file to disk', async () => {
   expect(imports['netlify:edge']).toBe('https://edge.netlify.com/v1/index.ts?v=legacy')
   expect(imports['@netlify/edge-functions']).toBe('https://edge.netlify.com/v1/index.ts')
   expect(imports['alias:pets']).toBe(pathToFileURL(expectedPath).toString())
+})
+
+test.only('Clones an import map', () => {
+  const basePath = join(cwd(), 'my-cool-site', 'import-map.json')
+  const inputFile1 = {
+    baseURL: pathToFileURL(basePath),
+    imports: {
+      'alias:jamstack': 'https://jamstack.org',
+    },
+  }
+  const inputFile2 = {
+    baseURL: pathToFileURL(basePath),
+    imports: {
+      'alias:pets': 'https://petsofnetlify.com/',
+    },
+  }
+
+  const map1 = new ImportMap([inputFile1, inputFile2])
+  const map2 = map1.clone()
+
+  map2.add({
+    baseURL: pathToFileURL(basePath),
+    imports: {
+      netlify: 'https://netlify.com',
+    },
+  })
+
+  expect(map1.getContents()).toStrictEqual({
+    imports: {
+      'netlify:edge': 'https://edge.netlify.com/v1/index.ts?v=legacy',
+      '@netlify/edge-functions': 'https://edge.netlify.com/v1/index.ts',
+      'alias:jamstack': 'https://jamstack.org/',
+      'alias:pets': 'https://petsofnetlify.com/',
+    },
+    scopes: {},
+  })
+
+  expect(map2.getContents()).toStrictEqual({
+    imports: {
+      'netlify:edge': 'https://edge.netlify.com/v1/index.ts?v=legacy',
+      '@netlify/edge-functions': 'https://edge.netlify.com/v1/index.ts',
+      'alias:jamstack': 'https://jamstack.org/',
+      'alias:pets': 'https://petsofnetlify.com/',
+      netlify: 'https://netlify.com/',
+    },
+    scopes: {},
+  })
 })

--- a/node/import_map.test.ts
+++ b/node/import_map.test.ts
@@ -176,7 +176,7 @@ test('Writes import map file to disk', async () => {
   expect(imports['alias:pets']).toBe(pathToFileURL(expectedPath).toString())
 })
 
-test.only('Clones an import map', () => {
+test('Clones an import map', () => {
   const basePath = join(cwd(), 'my-cool-site', 'import-map.json')
   const inputFile1 = {
     baseURL: pathToFileURL(basePath),

--- a/node/import_map.ts
+++ b/node/import_map.ts
@@ -31,8 +31,8 @@ export class ImportMap {
   // The different import map files that make up the wider import map.
   sources: ImportMapFile[]
 
-  constructor(sources: ImportMapFile[] = [], rootURL: string | null = null) {
-    this.rootPath = rootURL ? fileURLToPath(rootURL) : null
+  constructor(sources: ImportMapFile[] = [], rootPath: string | null = null) {
+    this.rootPath = rootPath
     this.sources = []
 
     sources.forEach((file) => {
@@ -74,6 +74,10 @@ export class ImportMap {
       }),
       {},
     )
+  }
+
+  clone() {
+    return new ImportMap(this.sources, this.rootPath)
   }
 
   static convertImportsToURLObjects(imports: Imports) {

--- a/node/server/server.test.ts
+++ b/node/server/server.test.ts
@@ -2,6 +2,7 @@ import { join } from 'path'
 
 import getPort from 'get-port'
 import fetch from 'node-fetch'
+import { tmpName } from 'tmp-promise'
 import { v4 as uuidv4 } from 'uuid'
 import { test, expect } from 'vitest'
 
@@ -16,10 +17,13 @@ test('Starts a server and serves requests for edge functions', async () => {
   }
   const port = await getPort()
   const importMapPaths = [join(paths.internal, 'import_map.json'), join(paths.user, 'import-map.json')]
+  const servePath = await tmpName()
   const server = await serve({
+    basePath,
     bootstrapURL: 'https://edge.netlify.com/bootstrap/index-combined.ts',
     importMapPaths,
     port,
+    servePath,
   })
 
   const functions = [


### PR DESCRIPTION
**Which problem is this pull request solving?**

Another follow-up to #454, supporting npm modules in the `serve` entry point.

This is technically a breaking change since `serve` now expects new `basePath` and `servePath` parameters.