### PR TITLE
fix: detect .mjs files

### DIFF
--- a/node/finder.ts
+++ b/node/finder.ts
@@ -6,7 +6,7 @@ import { nonNullable } from './utils/non_nullable.js'
 
 // the order of the allowed extensions is also the order we remove duplicates
 // with a lower index meaning a higher precedence over the others
-const ALLOWED_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx']
+const ALLOWED_EXTENSIONS = ['.js', '.jsx', '.mjs', '.mts', '.ts', '.tsx']
 
 export const removeDuplicatesByExtension = (functions: string[]) => {
   const seen = new Map()


### PR DESCRIPTION
We're supporting `.mjs` files in Netlify Functions, so we should do the same for Edge Functions.

I'm not adding `.cjs` here, since Edge Functions need to be ES Modules.