### PR TITLE
feat: allow injecting user-facing logger

### DIFF
--- a/node/bridge.ts
+++ b/node/bridge.ts
@@ -56,7 +56,7 @@ class DenoBridge {
     this.cacheDirectory = options.cacheDirectory ?? getPathInHome('deno-cli')
     this.debug = options.debug ?? false
     this.denoDir = options.denoDir
-    this.logger = options.logger ?? getLogger(undefined, options.debug)
+    this.logger = options.logger ?? getLogger(undefined, undefined, options.debug)
     this.onAfterDownload = options.onAfterDownload
     this.onBeforeDownload = options.onBeforeDownload
     this.useGlobal = options.useGlobal ?? true

--- a/node/bundler.ts
+++ b/node/bundler.ts
@@ -34,6 +34,7 @@ export interface BundleOptions {
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   systemLogger?: LogFunction
+  userLogger?: LogFunction
   vendorDirectory?: string
 }
 
@@ -52,11 +53,12 @@ export const bundle = async (
     internalSrcFolder,
     onAfterDownload,
     onBeforeDownload,
+    userLogger,
     systemLogger,
     vendorDirectory,
   }: BundleOptions = {},
 ) => {
-  const logger = getLogger(systemLogger, debug)
+  const logger = getLogger(systemLogger, userLogger, debug)
   const featureFlags = getFlags(inputFeatureFlags)
   const options: DenoOptions = {
     debug,

--- a/node/logger.test.ts
+++ b/node/logger.test.ts
@@ -13,12 +13,12 @@ afterEach(() => {
   console.log = consoleLog
 })
 
-test('Prints user logs to stdout', () => {
+test('Prints user logs to stdout if no user logger is provided', () => {
   const mockConsoleLog = vi.fn()
   console.log = mockConsoleLog
 
-  const logger1 = getLogger(noopLogger, true)
-  const logger2 = getLogger(noopLogger, false)
+  const logger1 = getLogger(noopLogger, undefined, true)
+  const logger2 = getLogger(noopLogger, undefined, false)
 
   logger1.user('Hello with `debug: true`')
   logger2.user('Hello with `debug: false`')
@@ -28,13 +28,23 @@ test('Prints user logs to stdout', () => {
   expect(mockConsoleLog).toHaveBeenNthCalledWith(2, 'Hello with `debug: false`')
 })
 
+test('Prints user logs to user logger provided', () => {
+  const userLogger = vi.fn()
+  const logger = getLogger(noopLogger, userLogger, true)
+
+  logger.user('Hello!')
+
+  expect(userLogger).toHaveBeenCalledTimes(1)
+  expect(userLogger).toHaveBeenNthCalledWith(1, 'Hello!')
+})
+
 test('Prints system logs to the system logger provided', () => {
   const mockSystemLog = vi.fn()
   const mockConsoleLog = vi.fn()
   console.log = mockSystemLog
 
-  const logger1 = getLogger(mockSystemLog, true)
-  const logger2 = getLogger(mockSystemLog, false)
+  const logger1 = getLogger(mockSystemLog, undefined, true)
+  const logger2 = getLogger(mockSystemLog, undefined, false)
 
   logger1.system('Hello with `debug: true`')
   logger2.system('Hello with `debug: false`')
@@ -49,8 +59,8 @@ test('Prints system logs to stdout if there is no system logger provided and `de
   const mockConsoleLog = vi.fn()
   console.log = mockConsoleLog
 
-  const logger1 = getLogger(undefined, true)
-  const logger2 = getLogger(undefined, false)
+  const logger1 = getLogger(undefined, undefined, true)
+  const logger2 = getLogger(undefined, undefined, false)
 
   logger1.system('Hello with `debug: true`')
   logger2.system('Hello with `debug: false`')

--- a/node/logger.ts
+++ b/node/logger.ts
@@ -9,15 +9,16 @@ interface Logger {
   user: LogFunction
 }
 
-const getLogger = (systemLogger?: LogFunction, debug = false): Logger => {
+const getLogger = (systemLogger?: LogFunction, userLogger?: LogFunction, debug = false): Logger => {
   // If there is a system logger configured, we'll use that. If there isn't,
   // we'll pipe system logs to stdout if `debug` is enabled and swallow them
   // otherwise.
   const system = systemLogger ?? (debug ? console.log : noopLogger)
+  const user = userLogger ?? console.log
 
   return {
     system,
-    user: console.log,
+    user,
   }
 }
 

--- a/node/server/server.ts
+++ b/node/server/server.ts
@@ -159,6 +159,7 @@ interface ServeOptions {
   formatImportError?: FormatFunction
   port: number
   servePath: string
+  userLogger?: LogFunction
   systemLogger?: LogFunction
 }
 
@@ -177,9 +178,10 @@ export const serve = async ({
   onBeforeDownload,
   port,
   servePath,
+  userLogger,
   systemLogger,
 }: ServeOptions) => {
-  const logger = getLogger(systemLogger, debug)
+  const logger = getLogger(systemLogger, userLogger, debug)
   const deno = new DenoBridge({
     debug,
     logger,


### PR DESCRIPTION
We should handle logging within the entrypoints of our systems, not within the satellite packages. This PR allows injecting a logging provider for user-facing logs.