### PR TITLE
fix: NPM bundling should use ESM format

### DIFF
--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -486,6 +486,7 @@ test('Handles imports with the `node:` prefix', async () => {
 })
 
 test('Loads npm modules from bare specifiers', async () => {
+  const systemLogger = vi.fn()
   const { basePath, cleanup, distPath } = await useFixture('imports_npm_module')
   const sourceDirectory = join(basePath, 'functions')
   const declarations: Declaration[] = [
@@ -501,7 +502,13 @@ test('Loads npm modules from bare specifiers', async () => {
     featureFlags: { edge_functions_npm_modules: true },
     importMapPaths: [join(basePath, 'import_map.json')],
     vendorDirectory: vendorDirectory.path,
+    systemLogger,
   })
+
+  expect(
+    systemLogger.mock.calls.find((call) => call[0] === 'Could not track dependencies in edge function:'),
+  ).toBeUndefined()
+
   const manifestFile = await readFile(resolve(distPath, 'manifest.json'), 'utf8')
   const manifest = JSON.parse(manifestFile)
   const bundlePath = join(distPath, manifest.bundles[0].asset)

--- a/node/npm_dependencies.ts
+++ b/node/npm_dependencies.ts
@@ -148,6 +148,7 @@ export const vendorNPMSpecifiers = async ({
       platform: 'node',
       plugins: [getDependencyTrackerPlugin(specifiers, importMap.getContentsWithURLObjects(), pathToFileURL(basePath))],
       write: false,
+      format: 'esm',
     })
   } catch (error) {
     logger.system('Could not track dependencies in edge function:', error)

--- a/test/fixtures/imports_npm_module/functions/func1.ts
+++ b/test/fixtures/imports_npm_module/functions/func1.ts
@@ -3,6 +3,8 @@ import parent2 from 'parent-2'
 import parent3 from './lib/util.ts'
 import { echo } from 'alias:helper'
 
+await Promise.resolve()
+
 export default async () => {
   const text = [parent1('JavaScript'), parent2('APIs'), parent3('Markup')].join(', ')
 


### PR DESCRIPTION
When we try detecting imported NPM modules, we use ESBuild. Right now, it sometimes fails that tracing process because of code-level errors. One specific example for that is top-level await, which is only available in ES Modules. This PR fixes this specific instance by switching the bundling format for NPM modules tracing from the (default) CJS format to ESM.