### PR TITLE
fix: NPM parsing shouldn't try loading Deno URL imports

### DIFF
--- a/node/bundler.test.ts
+++ b/node/bundler.test.ts
@@ -138,7 +138,10 @@ test('Prints a nice error message when user tries importing an npm module and np
   ]
 
   try {
-    await bundle([sourceDirectory], distPath, declarations, { basePath })
+    await bundle([sourceDirectory], distPath, declarations, {
+      basePath,
+      importMapPaths: [join(basePath, 'import_map.json')],
+    })
   } catch (error) {
     expect(error).toBeInstanceOf(BundleError)
     expect((error as BundleError).message).toEqual(

--- a/node/npm_dependencies.ts
+++ b/node/npm_dependencies.ts
@@ -53,6 +53,10 @@ export const getDependencyTrackerPlugin = (
       // If it does, the resolved import is the specifier we'll evaluate going
       // forward.
       if (matched) {
+        if (resolvedImport.protocol !== 'file:') {
+          return { external: true }
+        }
+
         specifier = fileURLToPath(resolvedImport).replace(/\\/g, '/')
 
         result.path = specifier

--- a/test/fixtures/imports_npm_module/functions/func1.ts
+++ b/test/fixtures/imports_npm_module/functions/func1.ts
@@ -2,8 +2,11 @@ import parent1 from 'parent-1'
 import parent2 from 'parent-2'
 import parent3 from './lib/util.ts'
 import { echo } from 'alias:helper'
+import { HTMLRewriter } from 'html-rewriter'
 
 await Promise.resolve()
+
+new HTMLRewriter()
 
 export default async () => {
   const text = [parent1('JavaScript'), parent2('APIs'), parent3('Markup')].join(', ')

--- a/test/fixtures/imports_npm_module/import_map.json
+++ b/test/fixtures/imports_npm_module/import_map.json
@@ -1,5 +1,6 @@
 {
   "imports": {
-    "alias:helper": "./helper.ts"
+    "alias:helper": "./helper.ts",
+    "html-rewriter": "https://ghuc.cc/worker-tools/html-rewriter/index.ts"
   }
 }


### PR DESCRIPTION
In our ESBuild plugin, we were trying to resolve values we read from an import map from disk. Sometimes, these values will be HTTP URLs though, like `https://esm.sh/react`. We can't load them from disk, and we don't need to - they're not NPM modules!

This PR adds a check for that, and ensures we only try reading `file:/` URLs from disk.