### PR TITLE
fix: give stable barrel file names

### DIFF
--- a/node/server/server.test.ts
+++ b/node/server/server.test.ts
@@ -100,12 +100,12 @@ test('Starts a server and serves requests for edge functions', async () => {
     local: 'i love netlify',
   })
 
-  const idBarrelFile = await readFile(join(servePath, 'barrel-0.js'), 'utf-8')
+  const idBarrelFile = await readFile(join(servePath, 'barrel-id.js'), 'utf-8')
   expect(idBarrelFile).toContain(
     `/// <reference types="${join('..', '..', '..', 'node_modules', 'id', 'types.d.ts')}" />`,
   )
 
-  const identidadeBarrelFile = await readFile(join(servePath, 'barrel-2.js'), 'utf-8')
+  const identidadeBarrelFile = await readFile(join(servePath, 'barrel-pt-committee__identidade.js'), 'utf-8')
   expect(identidadeBarrelFile).toContain(
     `/// <reference types="${join(
       '..',


### PR DESCRIPTION
Implements https://github.com/netlify/edge-bundler/pull/505#discussion_r1366666275. This also un-flakes the test we added in https://github.com/netlify/edge-bundler/pull/505, since the names no longer relies on the order that files are being read from disk in.