### PR TITLE
fix: relative path needs to be from directory, not from file

### DIFF
--- a/node/npm_dependencies.ts
+++ b/node/npm_dependencies.ts
@@ -273,7 +273,7 @@ export const vendorNPMSpecifiers = async ({
       const types = ops.find((op) => path.basename(file.path) === path.basename(op.filePath))?.types
       let content = file.text
       if (types) {
-        content = `/// <reference types="${path.relative(file.path, types)}" />\n${content}`
+        content = `/// <reference types="${path.relative(path.dirname(file.path), types)}" />\n${content}`
       }
       await fs.writeFile(file.path, content)
     }),

--- a/node/server/server.test.ts
+++ b/node/server/server.test.ts
@@ -101,20 +101,10 @@ test('Starts a server and serves requests for edge functions', async () => {
   })
 
   const idBarrelFile = await readFile(join(servePath, 'bundled-id.js'), 'utf-8')
-  expect(idBarrelFile).toContain(
-    `/// <reference types="${join('..', '..', '..', 'node_modules', 'id', 'types.d.ts')}" />`,
-  )
+  expect(idBarrelFile).toContain(`/// <reference types="${join('..', '..', 'node_modules', 'id', 'types.d.ts')}" />`)
 
   const identidadeBarrelFile = await readFile(join(servePath, 'bundled-pt-committee__identidade.js'), 'utf-8')
   expect(identidadeBarrelFile).toContain(
-    `/// <reference types="${join(
-      '..',
-      '..',
-      '..',
-      'node_modules',
-      '@types',
-      'pt-committee__identidade',
-      'index.d.ts',
-    )}" />`,
+    `/// <reference types="${join('..', '..', 'node_modules', '@types', 'pt-committee__identidade', 'index.d.ts')}" />`,
   )
 })


### PR DESCRIPTION
We were generating a relative path that went one level up too much. I think that's the standard behaviour of `path.relative`, because it can't differentiate between a path to a file, and a path to a directory. This PR fixes that.