### PR TITLE
fix: pass cache object to nft to save some work

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,6 +21,7 @@ module.exports = {
     'unicorn/prefer-json-parse-buffer': 'off',
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
+    'max-params': 'off',
   },
   overrides: [
     ...overrides,

--- a/node/declaration.ts
+++ b/node/declaration.ts
@@ -31,7 +31,6 @@ export const mergeDeclarations = (
   deployConfigDeclarations: Declaration[],
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _featureFlags: FeatureFlags = {},
-  // eslint-disable-next-line max-params
 ) => {
   const functionsVisited: Set<string> = new Set()
 

--- a/node/npm_dependencies.ts
+++ b/node/npm_dependencies.ts
@@ -103,10 +103,12 @@ const getNPMSpecifiers = async (
   functions: string[],
   importMap: ParsedImportMap,
   referenceTypes: boolean,
+  nftCache?: object,
 ) => {
   const baseURL = pathToFileURL(basePath)
   const { reasons } = await nodeFileTrace(functions, {
     base: basePath,
+    cache: nftCache,
     readFile: async (filePath: string) => {
       // If this is a TypeScript file, we need to compile in before we can
       // parse it.
@@ -203,6 +205,7 @@ interface VendorNPMSpecifiersOptions {
   importMap: ImportMap
   logger: Logger
   referenceTypes: boolean
+  nftCache?: object
 }
 
 export const vendorNPMSpecifiers = async ({
@@ -211,6 +214,7 @@ export const vendorNPMSpecifiers = async ({
   functions,
   importMap,
   referenceTypes,
+  nftCache,
 }: VendorNPMSpecifiersOptions) => {
   // The directories that esbuild will use when resolving Node modules. We must
   // set these manually because esbuild will be operating from a temporary
@@ -228,6 +232,7 @@ export const vendorNPMSpecifiers = async ({
     functions,
     importMap.getContentsWithURLObjects(),
     referenceTypes,
+    nftCache,
   )
 
   // If we found no specifiers, there's nothing left to do here.

--- a/node/server/server.ts
+++ b/node/server/server.ts
@@ -59,6 +59,7 @@ const prepareServer = ({
   logger,
   port,
 }: PrepareServerOptions) => {
+  const nftCache = Object.create(null)
   const processRef: ProcessRef = {}
   const startServer = async (
     functions: EdgeFunction[],
@@ -94,6 +95,7 @@ const prepareServer = ({
       importMap,
       logger,
       referenceTypes: true,
+      nftCache,
     })
 
     if (vendor) {


### PR DESCRIPTION
Part of https://linear.app/netlify/issue/COM-72/edge-functions-local-dev-dont-delete-files-on-every-build. 

Passing a cache object into NFT allows to save some work during local dev.

Next step is to use an [ESBuild Context](https://esbuild.github.io/api/#build) to save some work over there, but that requires a bigger refactoring - not sure if it's worth it.