### PR TITLE
fix: prevent global namespace clash for `Buffer`

### DIFF
--- a/node/npm_dependencies.ts
+++ b/node/npm_dependencies.ts
@@ -81,16 +81,19 @@ const safelyDetectTypes = async (packageJsonPath: string): Promise<string | unde
 // Workaround for https://github.com/evanw/esbuild/issues/1921.
 const banner = {
   js: `
-  import process from "node:process";
-  import {setImmediate, clearImmediate} from "node:timers";
-  import {Buffer} from "node:buffer";
-
+  import __nfyProcess from "node:process";
+  import {setImmediate as __nfySetImmediate, clearImmediate as __nfyClearImmediate} from "node:timers";
+  import {Buffer as __nfyBuffer} from "node:buffer";
   import {createRequire as ___nfyCreateRequire} from "node:module";
   import {fileURLToPath as ___nfyFileURLToPath} from "node:url";
   import {dirname as ___nfyPathDirname} from "node:path";
   let __filename=___nfyFileURLToPath(import.meta.url);
   let __dirname=___nfyPathDirname(___nfyFileURLToPath(import.meta.url));
   let require=___nfyCreateRequire(import.meta.url);
+  globalThis.process = __nfyProcess;
+  globalThis.setImmediate = __nfySetImmediate;
+  globalThis.clearImmediate = __nfyClearImmediate;
+  globalThis.Buffer = __nfyBuffer;
   `,
 }
 

--- a/test/fixtures/imports_npm_module/node_modules/child-1/index.js
+++ b/test/fixtures/imports_npm_module/node_modules/child-1/index.js
@@ -1,12 +1,13 @@
 import { readFileSync } from "fs"
 import { join } from "path"
+import { Buffer } from "node:buffer"
 
 export default (input) => {
   try {
     const filePath = input === "one" ? 'file1.txt' : 'file2.txt'
     const fileContents = readFileSync(join(__dirname, "files", filePath))
   
-    console.log(fileContents)
+    console.log(Buffer.from(fileContents).toString('utf-8'))
   } catch {
     // no-op
   }

--- a/test/fixtures/tsx/functions/func1.tsx
+++ b/test/fixtures/tsx/functions/func1.tsx
@@ -1,10 +1,3 @@
 import React from 'react'
 
-export default () => {
-  try {
-    // this is expected to fail
-    process.env.FOO
-  } catch {
-    return new Response(<p>Hello World</p>)
-  }
-}
+export default () => new Response(<p>Hello World</p>)


### PR DESCRIPTION
When bundling an NPM package that does `import { Buffer } from "node:buffer"`, like `@netlify/blobs`, then edge-bundler was outputting both the unchanged import from said package, plus another import via the Banner added in #519. Here's an excerpt for how the output looks:

```js

  ...
  import {Buffer} from "node:buffer";
  import {createRequire as ___nfyCreateRequire} from "node:module";
  import {fileURLToPath as ___nfyFileURLToPath} from "node:url";
  import {dirname as ___nfyPathDirname} from "node:path";
  let __filename=___nfyFileURLToPath(import.meta.url);
  let __dirname=___nfyPathDirname(___nfyFileURLToPath(import.meta.url));
  let require=___nfyCreateRequire(import.meta.url);
  

// test/fixtures/imports_npm_module/node_modules/child-1/index.js
import { Buffer } from "buffer";
...
```

Those two import lines clash at runtime. This PR fixes this, by populating the global namespace via writing onto `globalThis`. This solves it because it's shadowed by imports, but has the drawback that it also affects `globalThis` in user-code (see changed test). I'll see if I can find a workaround for this.