### PR TITLE
fix: support relative paths for NPM packages

### DIFF
--- a/node/npm_import_error.ts
+++ b/node/npm_import_error.ts
@@ -4,6 +4,8 @@ class NPMImportError extends Error {
       `There was an error when loading the '${moduleName}' npm module. Support for npm modules in edge functions is an experimental feature. Refer to https://ntl.fyi/edge-functions-npm for more information.`,
     )
 
+    console.error(originalError)
+
     this.name = 'NPMImportError'
     this.stack = originalError.stack
 

--- a/test/fixtures/imports_npm_module/functions/func1.ts
+++ b/test/fixtures/imports_npm_module/functions/func1.ts
@@ -2,6 +2,12 @@ import parent1 from 'parent-1'
 import parent3 from './lib/util.ts'
 import { echo, parent2 } from 'alias:helper'
 import { HTMLRewriter } from 'html-rewriter'
+import withSubpathIndex from "with-subpath"
+import withSubpathFoo from "with-subpath/foo"
+import assert from 'node:assert'
+
+assert(withSubpathIndex === "with-subpath/index")
+assert(withSubpathFoo === "with-subpath/foo")
 
 await Promise.resolve()
 

--- a/test/fixtures/imports_npm_module/node_modules/with-subpath/foo.js
+++ b/test/fixtures/imports_npm_module/node_modules/with-subpath/foo.js
@@ -1,0 +1,1 @@
+export default "with-subpath/foo"

--- a/test/fixtures/imports_npm_module/node_modules/with-subpath/index.js
+++ b/test/fixtures/imports_npm_module/node_modules/with-subpath/index.js
@@ -1,0 +1,1 @@
+export default "with-subpath/index"

--- a/test/fixtures/imports_npm_module/node_modules/with-subpath/package.json
+++ b/test/fixtures/imports_npm_module/node_modules/with-subpath/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "with-subpath",
+  "type": "module",
+  "exports": {
+    ".": "./index.js",
+    "./foo": "./foo.js"
+  }
+}


### PR DESCRIPTION
Some packages have multiple entrypoints, expressed via the `exports` field. We should handle those with our NPM bundling.

Surfaced through https://github.com/withastro/adapters/pull/84#discussion_r1415161346.