### PR TITLE
feat!: provide import maps when starting the isolate, not server

### DIFF
--- a/node/server/server.test.ts
+++ b/node/server/server.test.ts
@@ -22,7 +22,6 @@ test('Starts a server and serves requests for edge functions', async () => {
   const server = await serve({
     basePath,
     bootstrapURL: 'https://edge.netlify.com/bootstrap/index-combined.ts',
-    importMapPaths,
     port,
     servePath,
   })
@@ -43,6 +42,7 @@ test('Starts a server and serves requests for edge functions', async () => {
   ]
   const options = {
     getFunctionsConfig: true,
+    importMapPaths,
   }
 
   const { features, functionsConfig, graph, success, npmSpecifiersWithExtraneousFiles } = await server(
@@ -118,7 +118,6 @@ test('Serves edge functions in a monorepo setup', async () => {
   const server = await serve({
     basePath,
     bootstrapURL: 'https://edge.netlify.com/bootstrap/index-combined.ts',
-    importMapPaths,
     port,
     rootPath,
     servePath,
@@ -132,6 +131,7 @@ test('Serves edge functions in a monorepo setup', async () => {
   ]
   const options = {
     getFunctionsConfig: true,
+    importMapPaths,
   }
 
   const { features, functionsConfig, graph, success, npmSpecifiersWithExtraneousFiles } = await server(

--- a/node/server/server.ts
+++ b/node/server/server.ts
@@ -183,7 +183,6 @@ interface ServeOptions {
   distImportMapPath?: string
   featureFlags?: FeatureFlags
   inspectSettings?: InspectSettings
-  importMapPaths?: string[] | (() => Promise<string[]>)
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   formatExportTypeError?: FormatFunction

--- a/node/server/server.ts
+++ b/node/server/server.ts
@@ -27,7 +27,6 @@ interface PrepareServerOptions {
   flags: string[]
   formatExportTypeError?: FormatFunction
   formatImportError?: FormatFunction
-  importMap: ImportMap
   logger: Logger
   port: number
   rootPath?: string
@@ -35,6 +34,7 @@ interface PrepareServerOptions {
 
 interface StartServerOptions {
   getFunctionsConfig?: boolean
+  importMapPaths?: string[]
 }
 
 /**
@@ -57,7 +57,6 @@ const prepareServer = ({
   flags: denoFlags,
   formatExportTypeError,
   formatImportError,
-  importMap: baseImportMap,
   logger,
   port,
   rootPath,
@@ -88,7 +87,10 @@ const prepareServer = ({
     })
 
     const features: Record<string, boolean> = {}
-    const importMap = baseImportMap.clone()
+
+    const importMap = new ImportMap()
+    await importMap.addFiles(options.importMapPaths ?? [], logger)
+
     const npmSpecifiersWithExtraneousFiles: string[] = []
 
     // we keep track of the files that are relevant to the user's code, so we can clean up leftovers from past executions later
@@ -181,7 +183,7 @@ interface ServeOptions {
   distImportMapPath?: string
   featureFlags?: FeatureFlags
   inspectSettings?: InspectSettings
-  importMapPaths?: string[]
+  importMapPaths?: string[] | (() => Promise<string[]>)
   onAfterDownload?: OnAfterDownloadHook
   onBeforeDownload?: OnBeforeDownloadHook
   formatExportTypeError?: FormatFunction
@@ -242,11 +244,6 @@ export const serve = async ({
    * a function.
    */
   formatImportError,
-
-  /**
-   * Paths to any additional import map files.
-   */
-  importMapPaths = [],
 
   /**
    * Callback function to be triggered after the Deno CLI has been downloaded.
@@ -323,10 +320,6 @@ export const serve = async ({
     }
   }
 
-  const importMap = new ImportMap()
-
-  await importMap.addFiles(importMapPaths, logger)
-
   const server = prepareServer({
     basePath,
     bootstrapURL,
@@ -337,7 +330,6 @@ export const serve = async ({
     flags,
     formatExportTypeError,
     formatImportError,
-    importMap,
     logger,
     port,
     rootPath,


### PR DESCRIPTION
During local dev, the import map paths can change after startup. For example when a framework generates an import map after the dev server was already initiated. So we can't know all the paths up-front!

Currently, edge-bundler needs us pass all of them at startup. But it doesn't need them until invocation time.

This PR moves the import map parameter from startup time to invocation time, so we don't have to work around this in the CLI.