### PR TITLE
feat: support PCRE regexp engine

### DIFF
--- a/node/feature_flags.ts
+++ b/node/feature_flags.ts
@@ -1,4 +1,6 @@
-const defaultFlags = {}
+const defaultFlags = {
+  edge_bundler_pcre_regexp: false,
+}
 
 type FeatureFlag = keyof typeof defaultFlags
 type FeatureFlags = Partial<Record<FeatureFlag, boolean>>


### PR DESCRIPTION
**Which problem is this pull request solving?**

As we add a PCRE-compatible regular expression engine to our edge nodes, we must stop transforming regular expressions in Edge Bundler to make them compatible with the RE2 engine. We're doing this behind a feature flag.

Part of https://linear.app/netlify/issue/FRA-195/devise-strategy-to-handle-nextjs-routing-matchers.