### PR TITLE
feat: allow custom `stderr` and `stdout` in server

### DIFF
--- a/node/server/server.test.ts
+++ b/node/server/server.test.ts
@@ -109,10 +109,8 @@ test('Starts a server and serves requests for edge functions', async () => {
 })
 
 test('Serves edge functions in a monorepo setup', async () => {
-  const tmpFile1 = await tmp.file()
-  const tmpFile2 = await tmp.file()
-  const stderr = createWriteStream(tmpFile1.path)
-  const stdout = createWriteStream(tmpFile2.path)
+  const tmpFile = await tmp.file()
+  const stderr = createWriteStream(tmpFile.path)
 
   const rootPath = join(fixturesDir, 'monorepo_npm_module')
   const basePath = join(rootPath, 'packages', 'frontend')
@@ -129,7 +127,6 @@ test('Serves edge functions in a monorepo setup', async () => {
     rootPath,
     servePath,
     stderr,
-    stdout,
   })
 
   const functions = [
@@ -177,8 +174,7 @@ test('Serves edge functions in a monorepo setup', async () => {
     `<parent-1><child-1>JavaScript</child-1></parent-1>, <parent-2><child-2><grandchild-1>APIs<cwd>${process.cwd()}</cwd></grandchild-1></child-2></parent-2>, <parent-3><child-2><grandchild-1>Markup<cwd>${process.cwd()}</cwd></grandchild-1></child-2></parent-3>`,
   )
 
-  expect(await readFile(tmpFile2.path, 'utf8')).toContain('[func1] This is fine')
-  expect(await readFile(tmpFile1.path, 'utf8')).toContain('[func1] This is not')
+  expect(await readFile(tmpFile.path, 'utf8')).toContain('[func1] Something is on fire')
 
-  await Promise.all([tmpFile1.cleanup(), tmpFile2.cleanup()])
+  await tmpFile.cleanup()
 })

--- a/node/server/server.test.ts
+++ b/node/server/server.test.ts
@@ -1,9 +1,11 @@
+import { createWriteStream } from 'fs'
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 import process from 'process'
 
 import getPort from 'get-port'
 import fetch from 'node-fetch'
+import tmp from 'tmp-promise'
 import { v4 as uuidv4 } from 'uuid'
 import { test, expect } from 'vitest'
 
@@ -107,6 +109,11 @@ test('Starts a server and serves requests for edge functions', async () => {
 })
 
 test('Serves edge functions in a monorepo setup', async () => {
+  const tmpFile1 = await tmp.file()
+  const tmpFile2 = await tmp.file()
+  const stderr = createWriteStream(tmpFile1.path)
+  const stdout = createWriteStream(tmpFile2.path)
+
   const rootPath = join(fixturesDir, 'monorepo_npm_module')
   const basePath = join(rootPath, 'packages', 'frontend')
   const paths = {
@@ -121,6 +128,8 @@ test('Serves edge functions in a monorepo setup', async () => {
     port,
     rootPath,
     servePath,
+    stderr,
+    stdout,
   })
 
   const functions = [
@@ -141,6 +150,7 @@ test('Serves edge functions in a monorepo setup', async () => {
     },
     options,
   )
+
   expect(features).toEqual({ npmModules: true })
   expect(success).toBe(true)
   expect(functionsConfig).toEqual([{ path: '/func1' }])
@@ -161,8 +171,14 @@ test('Serves edge functions in a monorepo setup', async () => {
       'X-NF-Request-ID': uuidv4(),
     },
   })
+
   expect(response1.status).toBe(200)
   expect(await response1.text()).toBe(
     `<parent-1><child-1>JavaScript</child-1></parent-1>, <parent-2><child-2><grandchild-1>APIs<cwd>${process.cwd()}</cwd></grandchild-1></child-2></parent-2>, <parent-3><child-2><grandchild-1>Markup<cwd>${process.cwd()}</cwd></grandchild-1></child-2></parent-3>`,
   )
+
+  expect(await readFile(tmpFile2.path, 'utf8')).toContain('[func1] This is fine')
+  expect(await readFile(tmpFile1.path, 'utf8')).toContain('[func1] This is not')
+
+  await Promise.all([tmpFile1.cleanup(), tmpFile2.cleanup()])
 })

--- a/test/fixtures/monorepo_npm_module/packages/frontend/functions/func1.ts
+++ b/test/fixtures/monorepo_npm_module/packages/frontend/functions/func1.ts
@@ -8,6 +8,9 @@ await Promise.resolve()
 new HTMLRewriter()
 
 export default async () => {
+  console.log('This is fine')
+  console.error('This is not')
+
   const text = [parent1('JavaScript'), parent2('APIs'), parent3('Markup')].join(', ')
 
   return new Response(echo(text))

--- a/test/fixtures/monorepo_npm_module/packages/frontend/functions/func1.ts
+++ b/test/fixtures/monorepo_npm_module/packages/frontend/functions/func1.ts
@@ -8,8 +8,7 @@ await Promise.resolve()
 new HTMLRewriter()
 
 export default async () => {
-  console.log('This is fine')
-  console.error('This is not')
+  console.error('Something is on fire')
 
   const text = [parent1('JavaScript'), parent2('APIs'), parent3('Markup')].join(', ')
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

By default, the process that is spawned to run Deno in the serve mode will pipe the stderr and stdout to the corresponding descriptors of the parent process.

However, in some cases it's useful to be able to specify a different destination, such as when running tests and capturing output in a file on disk. To achieve that, this PR introduces two new parameters to the `serve` entry point that allow consumers to specify custom stderr and stdout.

If these parameters are not specified, the descriptors of the parent process continue to be used, so no breaking changes are being introduced.